### PR TITLE
週間スケジュールページのAPI対応

### DIFF
--- a/app/(admin)/admin/cast/list/page.tsx
+++ b/app/(admin)/admin/cast/list/page.tsx
@@ -126,7 +126,7 @@ export default function CastListPage() {
 
       <main className="p-4">
         {loading ? (
-          <div className="flex justify-center items-center min-h-[400px]">
+          <div className="flex min-h-[400px] items-center justify-center">
             <div className="text-gray-500">読み込み中...</div>
           </div>
         ) : (

--- a/app/(admin)/admin/cast/manage/[id]/page.tsx
+++ b/app/(admin)/admin/cast/manage/[id]/page.tsx
@@ -112,7 +112,7 @@ export default function CastManagePage({ params }: { params: Promise<{ id: strin
         publicProfile: data.publicProfile,
       }
       await castRepository.update(id, updateData)
-      
+
       // Update local state
       if (cast) {
         setCast({
@@ -120,7 +120,7 @@ export default function CastManagePage({ params }: { params: Promise<{ id: strin
           ...updateData,
         })
       }
-      
+
       toast({
         title: '成功',
         description: '公開プロフィールを更新しました',

--- a/app/(admin)/admin/cast/weekly-schedule/page.tsx
+++ b/app/(admin)/admin/cast/weekly-schedule/page.tsx
@@ -7,15 +7,18 @@ import { WeeklySchedule } from '@/lib/cast-schedule/old-types'
 import { Header } from '@/components/header'
 import { ScheduleInfoBar } from '@/components/cast-schedule/schedule-info-bar'
 import { ScheduleActionButtons } from '@/components/cast-schedule/schedule-action-buttons'
+import { toast } from '@/hooks/use-toast'
 
 const castScheduleUseCases = new CastScheduleUseCases()
 
 export default function WeeklySchedulePage() {
   const [date, setDate] = useState(() => new Date())
   const [schedule, setSchedule] = useState<WeeklySchedule | null>(null)
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     const fetchSchedule = async () => {
+      setLoading(true)
       try {
         const weeklySchedule = await castScheduleUseCases.getWeeklySchedule({
           date,
@@ -24,29 +27,55 @@ export default function WeeklySchedulePage() {
         setSchedule(weeklySchedule)
       } catch (error) {
         console.error('Failed to fetch schedule:', error)
+        toast({
+          title: 'エラー',
+          description: 'スケジュールの取得に失敗しました',
+          variant: 'destructive',
+        })
+      } finally {
+        setLoading(false)
       }
     }
 
     fetchSchedule()
   }, [date])
 
-  if (!schedule) {
-    return <div>Loading...</div>
+  if (loading || !schedule) {
+    return (
+      <div className="min-h-screen bg-gray-50">
+        <Header />
+        <div className="flex h-64 items-center justify-center">
+          <div className="text-center">
+            <div className="mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-b-2 border-emerald-600"></div>
+            <p className="text-gray-600">読み込み中...</p>
+          </div>
+        </div>
+      </div>
+    )
   }
 
-  const handleRefresh = () => {
-    const fetchSchedule = async () => {
-      try {
-        const weeklySchedule = await castScheduleUseCases.getWeeklySchedule({
-          date,
-          castFilter: 'all',
-        })
-        setSchedule(weeklySchedule)
-      } catch (error) {
-        console.error('Failed to fetch schedule:', error)
-      }
+  const handleRefresh = async () => {
+    setLoading(true)
+    try {
+      const weeklySchedule = await castScheduleUseCases.getWeeklySchedule({
+        date,
+        castFilter: 'all',
+      })
+      setSchedule(weeklySchedule)
+      toast({
+        title: '成功',
+        description: 'スケジュールを更新しました',
+      })
+    } catch (error) {
+      console.error('Failed to fetch schedule:', error)
+      toast({
+        title: 'エラー',
+        description: 'スケジュールの更新に失敗しました',
+        variant: 'destructive',
+      })
+    } finally {
+      setLoading(false)
     }
-    fetchSchedule()
   }
 
   const handleFilter = () => {
@@ -55,6 +84,84 @@ export default function WeeklySchedulePage() {
 
   const handleFilterCharacter = () => {
     // Character filter logic can be implemented here
+  }
+
+  const handleSaveSchedule = async (castId: string, schedule: any) => {
+    try {
+      // Convert the schedule format to match API expectations
+      const promises = Object.entries(schedule).map(
+        async ([dateStr, daySchedule]: [string, any]) => {
+          if (daySchedule.status === '出勤予定' && daySchedule.startTime && daySchedule.endTime) {
+            // Create or update schedule
+            const date = new Date(dateStr)
+            const startDateTime = new Date(`${dateStr}T${daySchedule.startTime}:00`)
+            const endDateTime = new Date(`${dateStr}T${daySchedule.endTime}:00`)
+
+            // Check if schedule exists for this date
+            const existingSchedules = await fetch(
+              `/api/cast-schedule?castId=${castId}&date=${dateStr}`
+            )
+            const existing = await existingSchedules.json()
+
+            if (existing.length > 0) {
+              // Update existing schedule
+              await fetch('/api/cast-schedule', {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  id: existing[0].id,
+                  startTime: startDateTime,
+                  endTime: endDateTime,
+                  isAvailable: true,
+                }),
+              })
+            } else {
+              // Create new schedule
+              await fetch('/api/cast-schedule', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  castId,
+                  date,
+                  startTime: startDateTime,
+                  endTime: endDateTime,
+                  isAvailable: true,
+                }),
+              })
+            }
+          } else if (daySchedule.status === '休日') {
+            // Delete existing schedule if any
+            const existingSchedules = await fetch(
+              `/api/cast-schedule?castId=${castId}&date=${dateStr}`
+            )
+            const existing = await existingSchedules.json()
+
+            if (existing.length > 0) {
+              await fetch(`/api/cast-schedule?id=${existing[0].id}`, {
+                method: 'DELETE',
+              })
+            }
+          }
+        }
+      )
+
+      await Promise.all(promises)
+
+      toast({
+        title: '成功',
+        description: 'スケジュールを保存しました',
+      })
+
+      // Refresh the schedule
+      handleRefresh()
+    } catch (error) {
+      console.error('Failed to save schedule:', error)
+      toast({
+        title: 'エラー',
+        description: 'スケジュールの保存に失敗しました',
+        variant: 'destructive',
+      })
+    }
   }
 
   return (
@@ -73,7 +180,11 @@ export default function WeeklySchedulePage() {
         date={date}
         onDateChange={setDate}
       />
-      <ScheduleGrid startDate={schedule.startDate} entries={schedule.entries} />
+      <ScheduleGrid
+        startDate={schedule.startDate}
+        entries={schedule.entries}
+        onSaveSchedule={handleSaveSchedule}
+      />
     </div>
   )
 }

--- a/app/(admin)/admin/reservation-list/page.tsx
+++ b/app/(admin)/admin/reservation-list/page.tsx
@@ -113,7 +113,7 @@ export default function ReservationListPage() {
         </div>
 
         {loading ? (
-          <div className="flex justify-center items-center min-h-[400px]">
+          <div className="flex min-h-[400px] items-center justify-center">
             <div className="text-gray-500">読み込み中...</div>
           </div>
         ) : (

--- a/app/api/cast-schedule/route.ts
+++ b/app/api/cast-schedule/route.ts
@@ -6,8 +6,23 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { db } from '@/lib/db'
 import logger from '@/lib/logger'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth/config'
+
+async function requireAdmin() {
+  const session = await getServerSession(authOptions)
+
+  if (!session || session.user.role !== 'admin') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  return null
+}
 
 export async function GET(request: NextRequest) {
+  const authError = await requireAdmin()
+  if (authError) return authError
+
   try {
     const searchParams = request.nextUrl.searchParams
     const id = searchParams.get('id')
@@ -60,6 +75,9 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
+  const authError = await requireAdmin()
+  if (authError) return authError
+
   try {
     const data = await request.json()
 
@@ -87,6 +105,9 @@ export async function POST(request: NextRequest) {
 }
 
 export async function PUT(request: NextRequest) {
+  const authError = await requireAdmin()
+  if (authError) return authError
+
   try {
     const data = await request.json()
     const { id, ...updates } = data
@@ -119,6 +140,9 @@ export async function PUT(request: NextRequest) {
 }
 
 export async function DELETE(request: NextRequest) {
+  const authError = await requireAdmin()
+  if (authError) return authError
+
   try {
     const searchParams = request.nextUrl.searchParams
     const id = searchParams.get('id')

--- a/app/api/cast/route.ts
+++ b/app/api/cast/route.ts
@@ -35,11 +35,11 @@ const castSchema = z.object({
 // Helper function to check admin permissions
 async function requireAdmin() {
   const session = await getServerSession(authOptions)
-  
+
   if (!session || session.user.role !== 'admin') {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
-  
+
   return null
 }
 
@@ -96,7 +96,7 @@ export async function GET(request: NextRequest) {
     })
 
     // Transform database results to match frontend expectations
-    const transformedCasts = casts.map(cast => ({
+    const transformedCasts = casts.map((cast) => ({
       ...cast,
       nameKana: cast.name, // Temporary: use name as nameKana
       images: typeof cast.images === 'string' ? JSON.parse(cast.images) : cast.images,
@@ -118,13 +118,13 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json()
-    
+
     // Validate request body
     const validatedData = castSchema.parse(body)
-    
+
     // Remove fields that don't exist in DB
     const { nameKana, availableOptions, ...dbData } = validatedData
-    
+
     // Create cast in database
     const cast = await db.cast.create({
       data: {
@@ -132,9 +132,9 @@ export async function POST(request: NextRequest) {
         images: validatedData.images || [],
       },
     })
-    
+
     logger.info({ castId: cast.id }, 'Cast created successfully')
-    
+
     return NextResponse.json(cast, { status: 201 })
   } catch (error) {
     if (error instanceof z.ZodError) {
@@ -143,7 +143,7 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       )
     }
-    
+
     logger.error({ err: error }, 'Error creating cast')
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
@@ -157,34 +157,34 @@ export async function PUT(request: NextRequest) {
   try {
     const body = await request.json()
     const { id, ...updateData } = body
-    
+
     if (!id) {
       return NextResponse.json({ error: 'Cast ID is required' }, { status: 400 })
     }
-    
+
     // Validate update data
     const validatedData = castSchema.partial().parse(updateData)
-    
+
     // Check if cast exists
     const existingCast = await db.cast.findUnique({
       where: { id },
     })
-    
+
     if (!existingCast) {
       return NextResponse.json({ error: 'Cast not found' }, { status: 404 })
     }
-    
+
     // Remove fields that don't exist in DB
     const { nameKana, availableOptions, ...dbData } = validatedData
-    
+
     // Update cast in database
     const cast = await db.cast.update({
       where: { id },
       data: dbData,
     })
-    
+
     logger.info({ castId: cast.id }, 'Cast updated successfully')
-    
+
     return NextResponse.json(cast)
   } catch (error) {
     if (error instanceof z.ZodError) {
@@ -193,7 +193,7 @@ export async function PUT(request: NextRequest) {
         { status: 400 }
       )
     }
-    
+
     logger.error({ err: error }, 'Error updating cast')
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
@@ -207,27 +207,27 @@ export async function DELETE(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams
     const id = searchParams.get('id')
-    
+
     if (!id) {
       return NextResponse.json({ error: 'Cast ID is required' }, { status: 400 })
     }
-    
+
     // Check if cast exists
     const existingCast = await db.cast.findUnique({
       where: { id },
     })
-    
+
     if (!existingCast) {
       return NextResponse.json({ error: 'Cast not found' }, { status: 404 })
     }
-    
+
     // Delete cast from database
     await db.cast.delete({
       where: { id },
     })
-    
+
     logger.info({ castId: id }, 'Cast deleted successfully')
-    
+
     return NextResponse.json({ message: 'Cast deleted successfully' })
   } catch (error) {
     logger.error({ err: error }, 'Error deleting cast')

--- a/app/api/customer/route.ts
+++ b/app/api/customer/route.ts
@@ -18,7 +18,7 @@ export async function GET(request: NextRequest) {
     const authCustomerId = request.headers.get('x-customer-id')
     const searchParams = request.nextUrl.searchParams
     const id = searchParams.get('id')
-    
+
     const isAdmin = session?.user?.role === 'admin'
 
     if (id) {
@@ -66,7 +66,7 @@ export async function GET(request: NextRequest) {
     if (!isAdmin) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
     }
-    
+
     const customers = await db.customer.findMany({
       orderBy: { createdAt: 'desc' },
       select: {
@@ -80,7 +80,7 @@ export async function GET(request: NextRequest) {
         updatedAt: true,
       },
     })
-    
+
     return NextResponse.json(customers)
   } catch (error) {
     logger.error({ err: error }, 'Error fetching customer data')
@@ -146,7 +146,7 @@ export async function PUT(request: NextRequest) {
     const authCustomerId = request.headers.get('x-customer-id')
     const data = await request.json()
     const { id, password, ...updates } = data
-    
+
     const isAdmin = session?.user?.role === 'admin'
 
     // Allow admin or the customer themselves

--- a/app/api/settings/hotel/route.ts
+++ b/app/api/settings/hotel/route.ts
@@ -1,0 +1,169 @@
+/**
+ * @design_doc   Hotel settings API endpoints
+ * @related_to   Hotel settings page
+ * @known_issues Hotel data is stored in memory (not persisted to database)
+ */
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth/config'
+import { z } from 'zod'
+
+// In-memory storage for demo purposes
+// In production, this should be stored in database
+let hotelSettings = [
+  {
+    id: '1',
+    hotelName: 'アパホテル池袋',
+    area: '池袋',
+    roomCount: 20,
+    hourlyRate: 3000,
+    address: '東京都豊島区池袋1-1-1',
+    phone: '03-1111-1111',
+    checkInTime: '15:00',
+    checkOutTime: '10:00',
+    amenities: ['無料Wi-Fi', 'アメニティ完備', '24時間フロント'],
+    notes: 'キャスト専用の入口あり',
+  },
+  {
+    id: '2',
+    hotelName: 'ビジネスホテル新宿',
+    area: '新宿',
+    roomCount: 15,
+    hourlyRate: 3500,
+    address: '東京都新宿区新宿2-2-2',
+    phone: '03-2222-2222',
+    checkInTime: '14:00',
+    checkOutTime: '11:00',
+    amenities: ['無料Wi-Fi', '朝食付き', '駐車場'],
+    notes: '駅近で便利な立地',
+  },
+]
+
+// Validation schema
+const hotelSchema = z.object({
+  id: z.string().optional(),
+  hotelName: z.string().min(1),
+  area: z.string().min(1),
+  roomCount: z.number().min(0),
+  hourlyRate: z.number().min(0),
+  address: z.string().min(1),
+  phone: z.string().min(1),
+  checkInTime: z.string(),
+  checkOutTime: z.string(),
+  amenities: z.array(z.string()),
+  notes: z.string().optional(),
+})
+
+async function requireAdmin() {
+  const session = await getServerSession(authOptions)
+
+  if (!session || session.user.role !== 'admin') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  return null
+}
+
+export async function GET(request: NextRequest) {
+  const authError = await requireAdmin()
+  if (authError) return authError
+
+  return NextResponse.json(hotelSettings)
+}
+
+export async function POST(request: NextRequest) {
+  const authError = await requireAdmin()
+  if (authError) return authError
+
+  try {
+    const body = await request.json()
+
+    // Validate request body
+    const validatedData = hotelSchema.parse(body)
+
+    // Generate ID if not provided
+    const newHotel = {
+      ...validatedData,
+      id: validatedData.id || Date.now().toString(),
+    }
+
+    // Add to list
+    hotelSettings.push(newHotel)
+
+    return NextResponse.json(newHotel, { status: 201 })
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: 'Validation error', details: error.errors },
+        { status: 400 }
+      )
+    }
+
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  const authError = await requireAdmin()
+  if (authError) return authError
+
+  try {
+    const body = await request.json()
+    const { id, ...updateData } = body
+
+    if (!id) {
+      return NextResponse.json({ error: 'Hotel ID is required' }, { status: 400 })
+    }
+
+    // Validate update data
+    const validatedData = hotelSchema.parse({ id, ...updateData })
+
+    // Find and update hotel
+    const hotelIndex = hotelSettings.findIndex((h) => h.id === id)
+
+    if (hotelIndex === -1) {
+      return NextResponse.json({ error: 'Hotel not found' }, { status: 404 })
+    }
+
+    hotelSettings[hotelIndex] = validatedData
+
+    return NextResponse.json(validatedData)
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: 'Validation error', details: error.errors },
+        { status: 400 }
+      )
+    }
+
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  const authError = await requireAdmin()
+  if (authError) return authError
+
+  try {
+    const searchParams = request.nextUrl.searchParams
+    const id = searchParams.get('id')
+
+    if (!id) {
+      return NextResponse.json({ error: 'Hotel ID is required' }, { status: 400 })
+    }
+
+    // Find hotel index
+    const hotelIndex = hotelSettings.findIndex((h) => h.id === id)
+
+    if (hotelIndex === -1) {
+      return NextResponse.json({ error: 'Hotel not found' }, { status: 404 })
+    }
+
+    // Remove hotel
+    hotelSettings.splice(hotelIndex, 1)
+
+    return NextResponse.json({ message: 'Hotel deleted successfully' })
+  } catch (error) {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/settings/hotel/route.ts
+++ b/app/api/settings/hotel/route.ts
@@ -10,7 +10,19 @@ import { z } from 'zod'
 
 // In-memory storage for demo purposes
 // In production, this should be stored in database
-let hotelSettings = [
+let hotelSettings: Array<{
+  id: string
+  hotelName: string
+  area: string
+  roomCount: number
+  hourlyRate: number
+  address: string
+  phone: string
+  checkInTime: string
+  checkOutTime: string
+  amenities: string[]
+  notes: string
+}> = [
   {
     id: '1',
     hotelName: 'アパホテル池袋',
@@ -87,8 +99,11 @@ export async function POST(request: NextRequest) {
       id: validatedData.id || Date.now().toString(),
     }
 
-    // Add to list
-    hotelSettings.push(newHotel)
+    // Add to list with default notes if not provided
+    hotelSettings.push({
+      ...newHotel,
+      notes: newHotel.notes || '',
+    })
 
     return NextResponse.json(newHotel, { status: 201 })
   } catch (error) {
@@ -125,7 +140,10 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json({ error: 'Hotel not found' }, { status: 404 })
     }
 
-    hotelSettings[hotelIndex] = validatedData
+    hotelSettings[hotelIndex] = {
+      ...validatedData,
+      notes: validatedData.notes || '',
+    }
 
     return NextResponse.json(validatedData)
   } catch (error) {

--- a/app/api/settings/store/route.ts
+++ b/app/api/settings/store/route.ts
@@ -10,7 +10,22 @@ import { z } from 'zod'
 
 // In-memory storage for demo purposes
 // In production, this should be stored in database
-let storeSettings = {
+let storeSettings: {
+  storeName: string
+  address: string
+  phone: string
+  email: string
+  website: string
+  businessHours: string
+  description: string
+  zipCode: string
+  prefecture: string
+  city: string
+  building: string
+  businessDays: string
+  lastOrder: string
+  parkingInfo: string
+} = {
   storeName: '金の玉クラブ(池袋)',
   address: '東京都豊島区池袋2-1-1',
   phone: '03-1234-5678',
@@ -72,8 +87,13 @@ export async function PUT(request: NextRequest) {
     // Validate request body
     const validatedData = storeSettingsSchema.parse(body)
 
-    // Update settings
-    storeSettings = validatedData
+    // Update settings with defaults for optional fields
+    storeSettings = {
+      ...validatedData,
+      website: validatedData.website || '',
+      building: validatedData.building || '',
+      parkingInfo: validatedData.parkingInfo || '',
+    }
 
     return NextResponse.json(storeSettings)
   } catch (error) {

--- a/components/cast-schedule/schedule-grid.tsx
+++ b/components/cast-schedule/schedule-grid.tsx
@@ -16,9 +16,10 @@ import { ScheduleEditDialog, WeeklyScheduleEdit } from './schedule-edit-dialog'
 interface ScheduleGridProps {
   startDate: Date
   entries: CastScheduleEntry[]
+  onSaveSchedule?: (castId: string, schedule: WeeklyScheduleEdit) => void
 }
 
-export function ScheduleGrid({ startDate, entries }: ScheduleGridProps) {
+export function ScheduleGrid({ startDate, entries, onSaveSchedule }: ScheduleGridProps) {
   const dates = getWeekDates(startDate)
   const [editDialogOpen, setEditDialogOpen] = useState(false)
   const [selectedCast, setSelectedCast] = useState<CastScheduleEntry | null>(null)
@@ -28,10 +29,10 @@ export function ScheduleGrid({ startDate, entries }: ScheduleGridProps) {
     setEditDialogOpen(true)
   }
 
-  const handleSaveSchedule = (castId: string, schedule: WeeklyScheduleEdit) => {
-    // Here you would normally save to the backend
-    console.log('Saving schedule for cast:', castId, schedule)
-    // For now, just close the dialog
+  const handleSaveSchedule = async (castId: string, schedule: WeeklyScheduleEdit) => {
+    if (onSaveSchedule) {
+      await onSaveSchedule(castId, schedule)
+    }
     setEditDialogOpen(false)
     setSelectedCast(null)
   }


### PR DESCRIPTION
## Summary
- 週間スケジュールページをAPIベースに移行
- スケジュール編集ダイアログから直接保存できるように実装

## Changes
### API Updates
- `/api/cast-schedule` - 管理者認証を追加
- 全メソッド（GET/POST/PUT/DELETE）に認証チェックを実装

### UI Implementation
- `app/(admin)/admin/cast/weekly-schedule/page.tsx`
  - API経由でスケジュールを保存する機能を追加
  - ローディング状態の表示
  - エラーハンドリングとトースト通知
- `components/cast-schedule/schedule-grid.tsx`
  - `onSaveSchedule` プロパティを追加
  - 保存ハンドラーを親コンポーネントから受け取る

### Settings API Fixes
- ホテル/店舗設定APIの型エラーを修正
- オプショナルフィールドのデフォルト値設定

## Test plan
- [ ] 管理者でログイン
- [ ] 週間スケジュールページにアクセス
- [ ] キャストのスケジュールをクリックして編集ダイアログを開く
- [ ] 出勤予定/休日を設定して保存
- [ ] ページをリロードしてデータが保持されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)