### PR TITLE
Phase 3: establish UX foundations

### DIFF
--- a/app/(admin)/admin-layout-client.tsx
+++ b/app/(admin)/admin-layout-client.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/lib/utils'
 import { useNotification } from '@/contexts/notification-context'
 import { CTIProvider } from '@/components/cti/cti-provider'
 import { NotificationProvider } from '@/contexts/notification-context'
+import { PageLoading } from '@/components/ui/page-loading'
 
 function AdminLayoutContent({ children }: { children: ReactNode }) {
   const { hasNewNotifications } = useNotification()
@@ -13,7 +14,7 @@ function AdminLayoutContent({ children }: { children: ReactNode }) {
   return (
     <>
       <Header />
-      <div className="min-h-screen w-full pt-[83px]">
+      <div className="min-h-screen w-full">
         <main>
           <div className={cn('w-full', hasNewNotifications && 'has-notifications')}>{children}</div>
         </main>
@@ -25,7 +26,7 @@ function AdminLayoutContent({ children }: { children: ReactNode }) {
 export function AdminLayoutClient({ children }: { children: ReactNode }) {
   return (
     <NotificationProvider>
-      <Suspense fallback={<div>Loading...</div>}>
+      <Suspense fallback={<PageLoading label="管理画面を読み込んでいます" />}>
         <CTIProvider>
           <AdminLayoutContent>{children}</AdminLayoutContent>
         </CTIProvider>

--- a/app/(admin)/admin/analytics/annual-sales/page.tsx
+++ b/app/(admin)/admin/analytics/annual-sales/page.tsx
@@ -4,7 +4,8 @@ import { useEffect, useMemo, useState } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
-import { Printer, TrendingUp, TrendingDown, Users, Store, DollarSign, Calendar } from 'lucide-react'
+import { TrendingUp, TrendingDown, Users, Store, DollarSign, Calendar } from 'lucide-react'
+import { PrintButton } from '@/components/analytics/print-button'
 import {
   Select,
   SelectContent,
@@ -132,13 +133,7 @@ export default function AnnualReportPage() {
             </SelectContent>
           </Select>
         </div>
-        <Button
-          onClick={handlePrint}
-          className="bg-emerald-600 text-white hover:bg-emerald-700 print:hidden"
-        >
-          <Printer className="mr-2 h-4 w-4" />
-          印刷する
-        </Button>
+        <PrintButton onClick={handlePrint} />
       </div>
 
       {error && (

--- a/app/(admin)/admin/analytics/area-sales/page.tsx
+++ b/app/(admin)/admin/analytics/area-sales/page.tsx
@@ -4,15 +4,8 @@ import { useEffect, useMemo, useState } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
-import {
-  Printer,
-  TrendingUp,
-  TrendingDown,
-  MapPin,
-  DollarSign,
-  Users,
-  Activity,
-} from 'lucide-react'
+import { TrendingUp, TrendingDown, MapPin, DollarSign, Users, Activity } from 'lucide-react'
+import { PrintButton } from '@/components/analytics/print-button'
 import {
   Select,
   SelectContent,
@@ -192,13 +185,7 @@ export default function AreaSalesPage() {
             </SelectContent>
           </Select>
         </div>
-        <Button
-          onClick={handlePrint}
-          className="bg-emerald-600 text-white hover:bg-emerald-700 print:hidden"
-        >
-          <Printer className="mr-2 h-4 w-4" />
-          印刷する
-        </Button>
+        <PrintButton onClick={handlePrint} />
       </div>
 
       {error && (

--- a/app/(admin)/admin/analytics/cast-performance/page.tsx
+++ b/app/(admin)/admin/analytics/cast-performance/page.tsx
@@ -7,7 +7,8 @@
  */
 import { useMemo, useState } from 'react'
 import { Button } from '@/components/ui/button'
-import { Printer, RotateCcw } from 'lucide-react'
+import { RotateCcw } from 'lucide-react'
+import { PrintButton } from '@/components/analytics/print-button'
 import {
   Select,
   SelectContent,
@@ -141,10 +142,7 @@ export default function CastPerformancePage() {
               条件をリセット
             </Button>
           )}
-          <Button onClick={handlePrint} className="bg-emerald-600 text-white hover:bg-emerald-700">
-            <Printer className="mr-2 h-4 w-4" />
-            印刷する
-          </Button>
+          <PrintButton onClick={handlePrint} />
         </div>
       </div>
 

--- a/app/(admin)/admin/analytics/course-sales/page.tsx
+++ b/app/(admin)/admin/analytics/course-sales/page.tsx
@@ -4,7 +4,8 @@ import { useEffect, useMemo, useState } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
-import { Printer, TrendingUp, TrendingDown, Package, DollarSign, Users } from 'lucide-react'
+import { TrendingUp, TrendingDown, Package, DollarSign, Users } from 'lucide-react'
+import { PrintButton } from '@/components/analytics/print-button'
 import { MonthSelector } from '@/components/analytics/month-selector'
 import { CourseSalesChart } from '@/components/analytics/course-sales-chart'
 import { CourseSalesTable } from '@/components/analytics/course-sales-table'
@@ -160,13 +161,7 @@ export default function CourseSalesPage() {
             onMonthChange={setSelectedMonth}
           />
         </div>
-        <Button
-          onClick={handlePrint}
-          className="bg-emerald-600 text-white hover:bg-emerald-700 print:hidden"
-        >
-          <Printer className="mr-2 h-4 w-4" />
-          印刷する
-        </Button>
+        <PrintButton onClick={handlePrint} />
       </div>
 
       {error && (

--- a/app/(admin)/admin/analytics/daily-report/daily-report-client.tsx
+++ b/app/(admin)/admin/analytics/daily-report/daily-report-client.tsx
@@ -8,6 +8,7 @@ import { format } from 'date-fns'
 import { Button } from '@/components/ui/button'
 import { RefreshCw } from 'lucide-react'
 import { useStore } from '@/contexts/store-context'
+import { PageLoading } from '@/components/ui/page-loading'
 
 export function DailyReportPageClient() {
   const [selectedDate, setSelectedDate] = useState<Date>(new Date())
@@ -61,11 +62,11 @@ export function DailyReportPageClient() {
         </Button>
       </div>
       {isLoading ? (
-        <p>Loading...</p>
+        <PageLoading compact label="日報を読み込んでいます" />
       ) : report ? (
         <DailyReportTable report={report} />
       ) : (
-        <p>No data available</p>
+        <p className="text-sm text-muted-foreground">表示できる日報がありません。</p>
       )}
     </div>
   )

--- a/app/(admin)/admin/analytics/district-sales/page.tsx
+++ b/app/(admin)/admin/analytics/district-sales/page.tsx
@@ -9,7 +9,8 @@ import { useEffect, useMemo, useState } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
-import { Printer, TrendingUp, TrendingDown, MapPin, DollarSign, Users } from 'lucide-react'
+import { TrendingUp, TrendingDown, MapPin, DollarSign, Users } from 'lucide-react'
+import { PrintButton } from '@/components/analytics/print-button'
 import {
   Select,
   SelectContent,
@@ -275,13 +276,7 @@ export default function DistrictSalesPage() {
             </Select>
           </div>
         </div>
-        <Button
-          onClick={handlePrint}
-          className="bg-emerald-600 text-white hover:bg-emerald-700 print:hidden"
-        >
-          <Printer className="mr-2 h-4 w-4" />
-          印刷する
-        </Button>
+        <PrintButton onClick={handlePrint} />
       </div>
 
       {error && (

--- a/app/(admin)/admin/analytics/hourly-sales/page.tsx
+++ b/app/(admin)/admin/analytics/hourly-sales/page.tsx
@@ -6,7 +6,6 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
 import {
-  Printer,
   Clock,
   Users,
   TrendingUp,
@@ -18,6 +17,7 @@ import {
   ChevronLeft,
   ChevronRight,
 } from 'lucide-react'
+import { PrintButton } from '@/components/analytics/print-button'
 import {
   Select,
   SelectContent,
@@ -473,10 +473,7 @@ export default function HourlySalesPage() {
             来月
             <ChevronRight className="h-4 w-4" />
           </Button>
-          <Button onClick={handlePrint} className="bg-emerald-600 text-white hover:bg-emerald-700">
-            <Printer className="mr-2 h-4 w-4" />
-            印刷する
-          </Button>
+          <PrintButton onClick={handlePrint} />
         </div>
       </div>
 

--- a/app/(admin)/admin/analytics/marketing-channels/page.tsx
+++ b/app/(admin)/admin/analytics/marketing-channels/page.tsx
@@ -4,15 +4,8 @@ import { useEffect, useMemo, useState } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
-import {
-  Printer,
-  TrendingUp,
-  TrendingDown,
-  Megaphone,
-  DollarSign,
-  Target,
-  BarChart3,
-} from 'lucide-react'
+import { TrendingUp, TrendingDown, Megaphone, DollarSign, Target, BarChart3 } from 'lucide-react'
+import { PrintButton } from '@/components/analytics/print-button'
 import {
   Select,
   SelectContent,
@@ -237,13 +230,7 @@ export default function MarketingChannelsPage() {
             </SelectContent>
           </Select>
         </div>
-        <Button
-          onClick={handlePrint}
-          className="bg-emerald-600 text-white hover:bg-emerald-700 print:hidden"
-        >
-          <Printer className="mr-2 h-4 w-4" />
-          印刷する
-        </Button>
+        <PrintButton onClick={handlePrint} />
       </div>
 
       {error && (

--- a/app/(admin)/admin/analytics/monthly-sales/page.tsx
+++ b/app/(admin)/admin/analytics/monthly-sales/page.tsx
@@ -4,15 +4,8 @@ import { useEffect, useMemo, useState } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
-import {
-  Printer,
-  TrendingUp,
-  TrendingDown,
-  Users,
-  CreditCard,
-  DollarSign,
-  Calendar,
-} from 'lucide-react'
+import { TrendingUp, TrendingDown, Users, CreditCard, DollarSign, Calendar } from 'lucide-react'
+import { PrintButton } from '@/components/analytics/print-button'
 import { AnalyticsUseCases } from '@/lib/analytics/usecases'
 import { AnalyticsRepositoryImpl } from '@/lib/analytics/repository'
 import { MonthSelector } from '@/components/analytics/month-selector'
@@ -118,13 +111,7 @@ export default function MonthlyReportPage() {
             onMonthChange={setSelectedMonth}
           />
         </div>
-        <Button
-          onClick={handlePrint}
-          className="bg-emerald-600 text-white hover:bg-emerald-700 print:hidden"
-        >
-          <Printer className="mr-2 h-4 w-4" />
-          印刷する
-        </Button>
+        <PrintButton onClick={handlePrint} />
       </div>
 
       {/* KPIカード */}

--- a/app/(admin)/admin/analytics/option-sales/page.tsx
+++ b/app/(admin)/admin/analytics/option-sales/page.tsx
@@ -4,7 +4,8 @@ import { useEffect, useMemo, useState } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
-import { Printer, TrendingUp, TrendingDown, Package, DollarSign, Sparkles } from 'lucide-react'
+import { TrendingUp, TrendingDown, Package, DollarSign, Sparkles } from 'lucide-react'
+import { PrintButton } from '@/components/analytics/print-button'
 import {
   Select,
   SelectContent,
@@ -230,13 +231,7 @@ export default function OptionSalesPage() {
             </SelectContent>
           </Select>
         </div>
-        <Button
-          onClick={handlePrint}
-          className="bg-emerald-600 text-white hover:bg-emerald-700 print:hidden"
-        >
-          <Printer className="mr-2 h-4 w-4" />
-          印刷する
-        </Button>
+        <PrintButton onClick={handlePrint} />
       </div>
 
       {error && (

--- a/app/(admin)/admin/analytics/staff-attendance/page.tsx
+++ b/app/(admin)/admin/analytics/staff-attendance/page.tsx
@@ -5,7 +5,6 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
 import {
-  Printer,
   Users,
   Calendar,
   Sparkles,
@@ -14,6 +13,7 @@ import {
   ChevronLeft,
   ChevronRight,
 } from 'lucide-react'
+import { PrintButton } from '@/components/analytics/print-button'
 import {
   Select,
   SelectContent,
@@ -554,10 +554,7 @@ export default function StaffAttendancePage() {
             来月
             <ChevronRight className="h-4 w-4" />
           </Button>
-          <Button onClick={handlePrint} className="bg-emerald-600 text-white hover:bg-emerald-700">
-            <Printer className="mr-2 h-4 w-4" />
-            印刷する
-          </Button>
+          <PrintButton onClick={handlePrint} />
         </div>
       </div>
 

--- a/app/(admin)/admin/cast/list/page.tsx
+++ b/app/(admin)/admin/cast/list/page.tsx
@@ -6,7 +6,6 @@
  * @known_issues Filters apply to the current page
  */
 import { useState, useEffect, useCallback, useMemo } from 'react'
-import { Header } from '@/components/header'
 import { CastListView } from '@/components/cast/cast-list-view'
 import { Cast } from '@/lib/cast/types'
 import { CastRepositoryImpl } from '@/lib/cast/repository-impl'
@@ -16,6 +15,7 @@ import { CastListViewToggle } from '@/components/cast/cast-list-view-toggle'
 import { CastListInfoBar } from '@/components/cast/cast-list-info-bar'
 import { useStore } from '@/contexts/store-context'
 import { Button } from '@/components/ui/button'
+import { TableSkeleton } from '@/components/ui/page-loading'
 
 const PAGE_SIZE = 25
 
@@ -129,7 +129,6 @@ export default function CastListPage() {
 
   return (
     <div className="min-h-screen bg-white">
-      <Header />
       <CastListInfoBar />
       <CastListViewToggle view={view} onViewChange={setView} />
       <CastListActionButtons
@@ -144,9 +143,7 @@ export default function CastListPage() {
 
       <main className="p-4">
         {loading ? (
-          <div className="flex min-h-[400px] items-center justify-center">
-            <div className="text-gray-500">読み込み中...</div>
-          </div>
+          <TableSkeleton rows={6} columns={4} label="キャスト一覧を読み込んでいます" />
         ) : (
           <>
             <CastListView casts={filteredCasts} view={view} />

--- a/app/(admin)/admin/cast/manage/[id]/page.tsx
+++ b/app/(admin)/admin/cast/manage/[id]/page.tsx
@@ -10,7 +10,6 @@ import { useRouter } from 'next/navigation'
 import { CastForm } from '@/components/cast/cast-form'
 import { CastDashboard } from '@/components/cast/cast-dashboard'
 import { Cast } from '@/lib/cast/types'
-import { Header } from '@/components/header'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
@@ -160,7 +159,6 @@ export default function CastManagePage({ params }: { params: Promise<{ id: strin
   if (!isNewCast && !loading && !cast) {
     return (
       <div className="min-h-screen bg-gray-50">
-        <Header />
         <main className="flex flex-1 items-center justify-center px-6 py-16">
           <Card className="max-w-xl text-center">
             <CardHeader>
@@ -186,7 +184,6 @@ export default function CastManagePage({ params }: { params: Promise<{ id: strin
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       <main className="p-8">
         <div className="mb-6 flex items-center justify-between">
           <div>

--- a/app/(admin)/admin/cast/weekly-schedule/page.tsx
+++ b/app/(admin)/admin/cast/weekly-schedule/page.tsx
@@ -9,7 +9,6 @@ import React, { useState, useEffect } from 'react'
 import { ScheduleGrid } from '@/components/cast-schedule/schedule-grid'
 import { CastScheduleUseCases } from '@/lib/cast-schedule/usecases'
 import { WeeklySchedule } from '@/lib/cast-schedule/old-types'
-import { Header } from '@/components/header'
 import { ScheduleInfoBar } from '@/components/cast-schedule/schedule-info-bar'
 import { ScheduleActionButtons } from '@/components/cast-schedule/schedule-action-buttons'
 import { toast } from '@/hooks/use-toast'
@@ -52,7 +51,6 @@ export default function WeeklySchedulePage() {
   if (loading || !schedule) {
     return (
       <div className="min-h-screen bg-gray-50">
-        <Header />
         <div className="flex h-64 items-center justify-center">
           <div className="text-center">
             <div className="mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-b-2 border-emerald-600"></div>
@@ -176,7 +174,6 @@ export default function WeeklySchedulePage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       <ScheduleInfoBar
         totalCast={schedule.stats.totalCast}
         workingCast={schedule.stats.workingCast}

--- a/app/(admin)/admin/customers/[id]/page.tsx
+++ b/app/(admin)/admin/customers/[id]/page.tsx
@@ -78,6 +78,7 @@ import { toast } from '@/hooks/use-toast'
 import { mapReservationToReservationData } from '@/lib/reservation/transformers'
 import { PointAdjustmentDialog } from '@/components/admin/point-adjustment-dialog'
 import { useStore } from '@/contexts/store-context'
+import { PageLoading } from '@/components/ui/page-loading'
 import { buildStoreScopedEndpoint } from '@/lib/store/endpoints'
 import { normalizeCustomerEmail } from '@/lib/auth/customer-auth'
 import { isBcryptSafePassword } from '@/lib/auth/password-policy'
@@ -586,7 +587,7 @@ export default function CustomerProfile() {
   }, [insights])
 
   if (!customer) {
-    return <div className="flex h-64 items-center justify-center">Loading...</div>
+    return <PageLoading compact label="顧客情報を読み込んでいます" />
   }
 
   return (

--- a/app/(admin)/admin/customers/layout.tsx
+++ b/app/(admin)/admin/customers/layout.tsx
@@ -1,9 +1,6 @@
-import { Header } from '@/components/header'
-
 export default function CustomersLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       <main className="container mx-auto px-4 py-6">{children}</main>
     </div>
   )

--- a/app/(admin)/admin/customers/page.tsx
+++ b/app/(admin)/admin/customers/page.tsx
@@ -7,7 +7,6 @@
  */
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
-import { Header } from '@/components/header'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   Table,
@@ -21,6 +20,7 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Customer } from '@/lib/customer/types'
 import { toast } from '@/hooks/use-toast'
+import { TableSkeleton } from '@/components/ui/page-loading'
 
 const PAGE_SIZE = 25
 
@@ -64,7 +64,6 @@ export default function CustomerListPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       <main className="mx-auto max-w-6xl p-6">
         <div className="mb-6 flex items-center justify-between">
           <div>
@@ -82,9 +81,7 @@ export default function CustomerListPage() {
           </CardHeader>
           <CardContent>
             {loading ? (
-              <div className="flex h-48 items-center justify-center text-sm text-muted-foreground">
-                読み込み中...
-              </div>
+              <TableSkeleton rows={5} columns={6} label="顧客一覧を読み込んでいます" />
             ) : customers.length === 0 ? (
               <div className="flex h-48 items-center justify-center text-sm text-muted-foreground">
                 顧客が登録されていません。

--- a/app/(admin)/admin/reservation-list/page.tsx
+++ b/app/(admin)/admin/reservation-list/page.tsx
@@ -32,6 +32,7 @@ import { ja } from 'date-fns/locale'
 import { cn } from '@/lib/utils'
 import { useStore } from '@/contexts/store-context'
 import { hasPermission } from '@/lib/auth/permissions'
+import { TableSkeleton } from '@/components/ui/page-loading'
 
 const ADJUSTING_STATUSES = new Set(['pending', 'tentative', 'modifiable'])
 const PAGE_SIZE = 25
@@ -319,9 +320,7 @@ export default function ReservationListPage() {
         </div>
 
         {loading ? (
-          <div className="flex min-h-[400px] items-center justify-center">
-            <div className="text-gray-500">読み込み中...</div>
-          </div>
+          <TableSkeleton rows={8} columns={6} label="予約一覧を読み込んでいます" />
         ) : (
           <>
             <ReservationList

--- a/app/(admin)/admin/reservation/reservation-page-content.tsx
+++ b/app/(admin)/admin/reservation/reservation-page-content.tsx
@@ -8,7 +8,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { useSession } from 'next-auth/react'
-import { Header } from '@/components/header'
 import { DateNavigation } from '@/components/reservation/date-navigation'
 import { ActionButtons } from '@/components/reservation/action-buttons'
 import { Timeline } from '@/components/reservation/timeline'
@@ -496,7 +495,6 @@ export function ReservationPageContent() {
 
   return (
     <div className="min-h-screen bg-white">
-      <Header />
       <InfoBar selectedCustomer={selectedCustomer} />
       <DateNavigation selectedDate={selectedDate} onSelectDate={setSelectedDate} />
       <ViewToggle view={view} onViewChange={setView} />

--- a/app/(admin)/admin/reviews/page.tsx
+++ b/app/(admin)/admin/reviews/page.tsx
@@ -33,6 +33,7 @@ import {
 import { useToast } from '@/hooks/use-toast'
 import { Loader2, RefreshCw, ShieldCheck, Filter, Eye, EyeOff, Trash2, Star } from 'lucide-react'
 import { ConfirmDialog } from '@/components/shared/confirm-dialog'
+import { TableSkeleton } from '@/components/ui/page-loading'
 
 type StatusFilter = 'all' | 'published' | 'pending' | 'hidden'
 const PAGE_SIZE = 25
@@ -223,108 +224,114 @@ export default function AdminReviewsPage() {
             </div>
           </div>
 
-          <div className="overflow-hidden rounded-lg border bg-white">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead className="min-w-[180px]">口コミ</TableHead>
-                  <TableHead className="w-[120px]">キャスト</TableHead>
-                  <TableHead className="w-[100px]">評価</TableHead>
-                  <TableHead className="w-[110px]">状態</TableHead>
-                  <TableHead className="w-[160px]">投稿日</TableHead>
-                  <TableHead className="w-[200px] text-right">操作</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {filteredReviews.map((review) => {
-                  const badgeInfo = statusLabels[review.status]
-                  const createdAt =
-                    review.createdAt instanceof Date ? review.createdAt : new Date(review.createdAt)
-                  return (
-                    <TableRow key={review.id}>
-                      <TableCell>
-                        <div className="space-y-1">
-                          <p className="line-clamp-3 text-sm text-gray-700">{review.comment}</p>
-                          <p className="text-xs text-gray-500">
-                            投稿者: {review.customerAlias}
-                            {review.customerArea ? ` / ${review.customerArea}` : ''}
-                          </p>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <div className="text-sm font-medium">{review.castName}</div>
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex items-center gap-1 text-sm">
-                          <Star className="h-4 w-4 fill-yellow-400 text-yellow-400" />
-                          {review.rating.toFixed(1)}
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant={badgeInfo.variant} className={badgeInfo.className}>
-                          {badgeInfo.label}
-                        </Badge>
-                      </TableCell>
-                      <TableCell>
-                        <div className="text-sm text-gray-600">
-                          {format(createdAt, 'yyyy年MM月dd日 HH:mm', { locale: ja })}
-                        </div>
-                      </TableCell>
-                      <TableCell className="text-right">
-                        <div className="flex flex-wrap justify-end gap-2">
-                          {review.status !== 'published' && (
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              onClick={() => handleUpdateStatus(review.id, 'published')}
+          {isLoading ? (
+            <TableSkeleton rows={6} columns={6} label="口コミ一覧を読み込んでいます" />
+          ) : (
+            <div className="overflow-hidden rounded-lg border bg-white">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="min-w-[180px]">口コミ</TableHead>
+                    <TableHead className="w-[120px]">キャスト</TableHead>
+                    <TableHead className="w-[100px]">評価</TableHead>
+                    <TableHead className="w-[110px]">状態</TableHead>
+                    <TableHead className="w-[160px]">投稿日</TableHead>
+                    <TableHead className="w-[200px] text-right">操作</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filteredReviews.map((review) => {
+                    const badgeInfo = statusLabels[review.status]
+                    const createdAt =
+                      review.createdAt instanceof Date
+                        ? review.createdAt
+                        : new Date(review.createdAt)
+                    return (
+                      <TableRow key={review.id}>
+                        <TableCell>
+                          <div className="space-y-1">
+                            <p className="line-clamp-3 text-sm text-gray-700">{review.comment}</p>
+                            <p className="text-xs text-gray-500">
+                              投稿者: {review.customerAlias}
+                              {review.customerArea ? ` / ${review.customerArea}` : ''}
+                            </p>
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <div className="text-sm font-medium">{review.castName}</div>
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex items-center gap-1 text-sm">
+                            <Star className="h-4 w-4 fill-yellow-400 text-yellow-400" />
+                            {review.rating.toFixed(1)}
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant={badgeInfo.variant} className={badgeInfo.className}>
+                            {badgeInfo.label}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>
+                          <div className="text-sm text-gray-600">
+                            {format(createdAt, 'yyyy年MM月dd日 HH:mm', { locale: ja })}
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <div className="flex flex-wrap justify-end gap-2">
+                            {review.status !== 'published' && (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() => handleUpdateStatus(review.id, 'published')}
+                              >
+                                <Eye className="mr-1 h-3.5 w-3.5" /> 公開する
+                              </Button>
+                            )}
+                            {review.status !== 'hidden' && (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() => handleUpdateStatus(review.id, 'hidden')}
+                              >
+                                <EyeOff className="mr-1 h-3.5 w-3.5" /> 非公開
+                              </Button>
+                            )}
+                            {review.status !== 'pending' && (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() => handleUpdateStatus(review.id, 'pending')}
+                              >
+                                <Filter className="mr-1 h-3.5 w-3.5" /> 審査中に戻す
+                              </Button>
+                            )}
+                            <ConfirmDialog
+                              title="口コミを削除しますか？"
+                              description="この操作は取り消せません。"
+                              confirmLabel="削除する"
+                              onConfirm={() => handleDelete(review.id)}
                             >
-                              <Eye className="mr-1 h-3.5 w-3.5" /> 公開する
-                            </Button>
-                          )}
-                          {review.status !== 'hidden' && (
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              onClick={() => handleUpdateStatus(review.id, 'hidden')}
-                            >
-                              <EyeOff className="mr-1 h-3.5 w-3.5" /> 非公開
-                            </Button>
-                          )}
-                          {review.status !== 'pending' && (
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              onClick={() => handleUpdateStatus(review.id, 'pending')}
-                            >
-                              <Filter className="mr-1 h-3.5 w-3.5" /> 審査中に戻す
-                            </Button>
-                          )}
-                          <ConfirmDialog
-                            title="口コミを削除しますか？"
-                            description="この操作は取り消せません。"
-                            confirmLabel="削除する"
-                            onConfirm={() => handleDelete(review.id)}
-                          >
-                            <Button size="sm" variant="destructive">
-                              <Trash2 className="mr-1 h-3.5 w-3.5" /> 削除
-                            </Button>
-                          </ConfirmDialog>
-                        </div>
+                              <Button size="sm" variant="destructive">
+                                <Trash2 className="mr-1 h-3.5 w-3.5" /> 削除
+                              </Button>
+                            </ConfirmDialog>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    )
+                  })}
+
+                  {filteredReviews.length === 0 && (
+                    <TableRow>
+                      <TableCell colSpan={6} className="py-10 text-center text-sm text-gray-500">
+                        口コミが見つかりませんでした。
                       </TableCell>
                     </TableRow>
-                  )
-                })}
-
-                {filteredReviews.length === 0 && (
-                  <TableRow>
-                    <TableCell colSpan={6} className="py-10 text-center text-sm text-gray-500">
-                      口コミが見つかりませんでした。
-                    </TableCell>
-                  </TableRow>
-                )}
-              </TableBody>
-            </Table>
-          </div>
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          )}
           <div className="flex items-center justify-end gap-3">
             <Button
               variant="outline"

--- a/app/(admin)/admin/search/search-content.tsx
+++ b/app/(admin)/admin/search/search-content.tsx
@@ -10,7 +10,6 @@ import { useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { Header } from '@/components/header'
 
 interface CustomerSearchResult {
   id: string
@@ -65,7 +64,6 @@ export function SearchContent() {
 
   return (
     <div className="container mx-auto px-4 py-6">
-      <Header />
       <h1 className="mb-4 mt-6 text-2xl font-bold">検索結果: {query}</h1>
       {isLoading ? (
         <p>検索中...</p>

--- a/app/(admin)/admin/settings/admin-info/page.tsx
+++ b/app/(admin)/admin/settings/admin-info/page.tsx
@@ -8,7 +8,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useSession } from 'next-auth/react'
 import { PageHeader } from '@/components/admin/page-header'
-import { Header } from '@/components/header'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -388,7 +387,6 @@ export default function AdminInfoPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       <main className="p-8">
         <div className="mx-auto max-w-6xl space-y-6">
           <PageHeader

--- a/app/(admin)/admin/settings/area-info/page.tsx
+++ b/app/(admin)/admin/settings/area-info/page.tsx
@@ -7,7 +7,6 @@
  */
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { PageHeader } from '@/components/admin/page-header'
-import { Header } from '@/components/header'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -291,7 +290,6 @@ export default function AreaInfoPage() {
   if (loading) {
     return (
       <div className="min-h-screen bg-gray-50">
-        <Header />
         <main className="p-8">
           <div className="mx-auto max-w-5xl">
             <div className="flex h-64 items-center justify-center">
@@ -308,7 +306,6 @@ export default function AreaInfoPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       <main className="p-8">
         <div className="mx-auto max-w-6xl space-y-6">
           <PageHeader

--- a/app/(admin)/admin/settings/course-info/page.tsx
+++ b/app/(admin)/admin/settings/course-info/page.tsx
@@ -7,7 +7,6 @@
  */
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { PageHeader } from '@/components/admin/page-header'
-import { Header } from '@/components/header'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -286,7 +285,6 @@ export default function CourseInfoPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       <main className="p-8">
         <div className="mx-auto max-w-6xl space-y-6">
           <PageHeader

--- a/app/(admin)/admin/settings/designation-fees/page.tsx
+++ b/app/(admin)/admin/settings/designation-fees/page.tsx
@@ -7,7 +7,6 @@
  */
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { PageHeader } from '@/components/admin/page-header'
-import { Header } from '@/components/header'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import {
@@ -223,7 +222,6 @@ export default function DesignationFeesPage() {
 
   return (
     <div className="flex min-h-screen flex-col">
-      <Header />
       <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-6 px-6 pb-12 pt-8">
         <PageHeader
           title="指名料設定"

--- a/app/(admin)/admin/settings/event-banners/page.tsx
+++ b/app/(admin)/admin/settings/event-banners/page.tsx
@@ -15,7 +15,6 @@ import {
   type ReactNode,
 } from 'react'
 import { PageHeader } from '@/components/admin/page-header'
-import { Header } from '@/components/header'
 import { useStore } from '@/contexts/store-context'
 import { toast } from '@/hooks/use-toast'
 import { buildStoreScopedEndpoint } from '@/lib/store/endpoints'
@@ -281,7 +280,6 @@ export default function EventBannersPage() {
   if (loading) {
     return (
       <div className="min-h-screen bg-gray-50">
-        <Header />
         <main className="p-8">
           <div className="mx-auto max-w-5xl">
             <div className="flex h-64 items-center justify-center">
@@ -298,7 +296,6 @@ export default function EventBannersPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       <main className="p-8">
         <div className="mx-auto max-w-5xl space-y-6">
           <PageHeader

--- a/app/(admin)/admin/settings/hotel-info/page.tsx
+++ b/app/(admin)/admin/settings/hotel-info/page.tsx
@@ -8,7 +8,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import Link from 'next/link'
 import { PageHeader } from '@/components/admin/page-header'
-import { Header } from '@/components/header'
 import { toast } from '@/hooks/use-toast'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -197,7 +196,6 @@ export default function HotelInfoPage() {
   if (loading) {
     return (
       <div className="min-h-screen bg-gray-50">
-        <Header />
         <main className="p-8">
           <div className="mx-auto max-w-6xl">
             <div className="flex h-64 items-center justify-center">
@@ -214,7 +212,6 @@ export default function HotelInfoPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       <main className="p-8">
         <div className="mx-auto max-w-6xl">
           <PageHeader

--- a/app/(admin)/admin/settings/hp-pricing/page.tsx
+++ b/app/(admin)/admin/settings/hp-pricing/page.tsx
@@ -6,7 +6,6 @@
  * @known_issues This page remains a prepared UI shell
  */
 import { PageHeader } from '@/components/admin/page-header'
-import { Header } from '@/components/header'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -15,7 +14,6 @@ import { ArrowLeft, CreditCard, Edit, PlusCircle } from 'lucide-react'
 export default function HpPricingPage() {
   return (
     <div className="flex min-h-screen flex-col">
-      <Header />
       <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-6 px-6 pb-12 pt-8">
         <PageHeader
           title="HP料金情報"

--- a/app/(admin)/admin/settings/mutual-links/page.tsx
+++ b/app/(admin)/admin/settings/mutual-links/page.tsx
@@ -6,7 +6,6 @@
  * @known_issues This page remains a prepared UI shell
  */
 import { PageHeader } from '@/components/admin/page-header'
-import { Header } from '@/components/header'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -15,7 +14,6 @@ import { ArrowLeft, Link2, PlusCircle } from 'lucide-react'
 export default function MutualLinksPage() {
   return (
     <div className="flex min-h-screen flex-col">
-      <Header />
       <main className="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-6 px-6 pb-12 pt-8">
         <PageHeader
           title="相互リンク"

--- a/app/(admin)/admin/settings/option-info/page.tsx
+++ b/app/(admin)/admin/settings/option-info/page.tsx
@@ -7,7 +7,6 @@
  */
 import { useState, useEffect, useCallback } from 'react'
 import { PageHeader } from '@/components/admin/page-header'
-import { Header } from '@/components/header'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -285,7 +284,6 @@ export default function OptionInfoPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       <main className="p-8">
         <div className="mx-auto max-w-6xl">
           <PageHeader

--- a/app/(admin)/admin/settings/station-info/page.tsx
+++ b/app/(admin)/admin/settings/station-info/page.tsx
@@ -7,7 +7,6 @@
  */
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { PageHeader } from '@/components/admin/page-header'
-import { Header } from '@/components/header'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -356,7 +355,6 @@ export default function StationInfoPage() {
   if (loading) {
     return (
       <div className="min-h-screen bg-gray-50">
-        <Header />
         <main className="p-8">
           <div className="mx-auto max-w-6xl">
             <div className="flex h-64 items-center justify-center">
@@ -373,7 +371,6 @@ export default function StationInfoPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       <main className="p-8">
         <div className="mx-auto max-w-6xl space-y-6">
           <PageHeader

--- a/app/(admin)/admin/settings/store-info/page.tsx
+++ b/app/(admin)/admin/settings/store-info/page.tsx
@@ -7,7 +7,6 @@
  */
 import { useState, useEffect, useCallback } from 'react'
 import { PageHeader } from '@/components/admin/page-header'
-import { Header } from '@/components/header'
 import { useStore } from '@/contexts/store-context'
 import { toast } from '@/hooks/use-toast'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -149,7 +148,6 @@ export default function StoreInfoPage() {
   if (loading) {
     return (
       <div className="min-h-screen bg-gray-50">
-        <Header />
         <main className="p-8">
           <div className="mx-auto max-w-4xl">
             <div className="flex h-64 items-center justify-center">
@@ -166,7 +164,6 @@ export default function StoreInfoPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header />
       <main className="p-8">
         <div className="mx-auto max-w-4xl">
           <PageHeader

--- a/app/(admin)/admin/settings/templates/page.tsx
+++ b/app/(admin)/admin/settings/templates/page.tsx
@@ -6,7 +6,6 @@
  * @known_issues This page remains a prepared UI shell
  */
 import { PageHeader } from '@/components/admin/page-header'
-import { Header } from '@/components/header'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -15,7 +14,6 @@ import { ArrowLeft, FileText, MessageSquare } from 'lucide-react'
 export default function TemplatesSettingsPage() {
   return (
     <div className="flex min-h-screen flex-col">
-      <Header />
       <main className="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-6 px-6 pb-12 pt-8">
         <PageHeader
           title="定型文"

--- a/app/[store]/age-verification/page.tsx
+++ b/app/[store]/age-verification/page.tsx
@@ -4,6 +4,11 @@
  * @known_issues Verification is self-attested and does not independently prove identity
  */
 import { AgeVerificationClient } from '@/components/age-verification-client'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: '年齢確認',
+}
 
 function sanitizeCallbackUrl(value: string | string[] | undefined, storeSlug: string): string {
   const candidate = Array.isArray(value) ? value[0] : value

--- a/app/[store]/forgot-password/page.tsx
+++ b/app/[store]/forgot-password/page.tsx
@@ -1,8 +1,18 @@
+/**
+ * @design_doc   docs/SYSTEM_AUDIT_2026-07-26.md J-12 store title consistency
+ * @related_to   ForgotPasswordForm: requests a customer recovery email
+ * @known_issues Delivery confirmation remains enumeration-safe
+ */
 import { notFound } from 'next/navigation'
+import type { Metadata } from 'next'
 import { fetchStoreBySlug } from '@/lib/store/public-api'
 import { ForgotPasswordForm } from '@/components/auth/forgot-password-form'
 import { StoreNavigation } from '@/components/store-navigation'
 import { StoreFooter } from '@/components/store-footer'
+
+export const metadata: Metadata = {
+  title: 'パスワード再設定',
+}
 
 export default async function ForgotPasswordPage({
   params,

--- a/app/[store]/login/page.tsx
+++ b/app/[store]/login/page.tsx
@@ -27,13 +27,6 @@ export default async function LoginPage({ params }: { params: Promise<{ store: s
       <StoreNavigation />
 
       <main className="min-h-screen bg-[#0b0b0b] text-foreground">
-        <div className="border-b border-[#2f2416] bg-[#0f0f0f] py-10">
-          <div className="mx-auto max-w-3xl px-4 text-center">
-            <p className="luxury-display text-xs tracking-[0.4em] text-[#d7b46a]">MEMBER LOGIN</p>
-            <h1 className="mt-4 text-2xl font-semibold text-[#f7e2b5] md:text-3xl">ログイン</h1>
-            <p className="mt-2 text-sm text-[#d7c39c]">会員の方はこちらからログインしてください</p>
-          </div>
-        </div>
         <div className="mx-auto max-w-md px-4 py-12">
           <LoginForm store={store} />
         </div>

--- a/app/[store]/mypage/page.tsx
+++ b/app/[store]/mypage/page.tsx
@@ -4,6 +4,7 @@
  * @known_issues None currently
  */
 import { redirect } from 'next/navigation'
+import type { Metadata } from 'next'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth/config'
 import { notFound } from 'next/navigation'
@@ -11,6 +12,10 @@ import { fetchStoreBySlug } from '@/lib/store/public-api'
 import { MyPageContent } from '@/components/mypage/mypage-content'
 import { StoreNavigation } from '@/components/store-navigation'
 import { StoreFooter } from '@/components/store-footer'
+
+export const metadata: Metadata = {
+  title: 'マイページ',
+}
 
 export default async function MyPage({ params }: { params: Promise<{ store: string }> }) {
   const { store: storeSlug } = await params

--- a/app/[store]/ranking/page.tsx
+++ b/app/[store]/ranking/page.tsx
@@ -1,4 +1,10 @@
+/**
+ * @design_doc   docs/SYSTEM_AUDIT_2026-07-26.md J-12 store title consistency
+ * @related_to   StoreLayout: applies the store-specific title template
+ * @known_issues Ranking content depends on persisted public cast data
+ */
 import { notFound } from 'next/navigation'
+import type { Metadata } from 'next'
 import { fetchStoreBySlug } from '@/lib/store/public-api'
 import { StoreNavigation } from '@/components/store-navigation'
 import { StoreFooter } from '@/components/store-footer'
@@ -12,6 +18,10 @@ import Link from 'next/link'
 import { getPublicRankingData } from '@/lib/store/public-casts'
 import { format } from 'date-fns'
 import { ja } from 'date-fns/locale'
+
+export const metadata: Metadata = {
+  title: 'ランキング',
+}
 
 function buildMeasurementLabel(cast: {
   height: number | null

--- a/app/[store]/recruitment/page.tsx
+++ b/app/[store]/recruitment/page.tsx
@@ -1,4 +1,10 @@
+/**
+ * @design_doc   docs/SYSTEM_AUDIT_2026-07-26.md J-12 store title consistency
+ * @related_to   StoreLayout: applies the store-specific title template
+ * @known_issues Recruitment content depends on persisted public cast data
+ */
 import { notFound } from 'next/navigation'
+import type { Metadata } from 'next'
 import { fetchStoreBySlug } from '@/lib/store/public-api'
 import { StoreNavigation } from '@/components/store-navigation'
 import { StoreFooter } from '@/components/store-footer'
@@ -11,6 +17,10 @@ import Link from 'next/link'
 import { format } from 'date-fns'
 import { ja } from 'date-fns/locale'
 import { getPublicRecruitmentData } from '@/lib/store/public-casts'
+
+export const metadata: Metadata = {
+  title: '入店情報',
+}
 
 function buildMeasurementLabel(cast: {
   height: number | null

--- a/app/[store]/services/page.tsx
+++ b/app/[store]/services/page.tsx
@@ -4,12 +4,17 @@
  * @known_issues Service content remains static until service settings are modeled
  */
 import { notFound } from 'next/navigation'
+import type { Metadata } from 'next'
 import { fetchStoreBySlug } from '@/lib/store/public-api'
 import { StoreNavigation } from '@/components/store-navigation'
 import { StoreFooter } from '@/components/store-footer'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Sparkles, Heart, Star, Shield } from 'lucide-react'
+
+export const metadata: Metadata = {
+  title: 'プレイ内容',
+}
 
 export default async function ServicesPage({ params }: { params: Promise<{ store: string }> }) {
   const { store: storeSlug } = await params

--- a/app/[store]/verify-phone/page.tsx
+++ b/app/[store]/verify-phone/page.tsx
@@ -4,9 +4,14 @@
  * @known_issues Missing store falls back to inline text instead of notFound
  */
 import { VerifyPhoneForm } from '@/components/auth/verify-phone-form'
+import type { Metadata } from 'next'
 import { fetchStoreBySlug } from '@/lib/store/public-api'
 import { StoreNavigation } from '@/components/store-navigation'
 import { StoreFooter } from '@/components/store-footer'
+
+export const metadata: Metadata = {
+  title: '電話番号認証',
+}
 
 export default async function VerifyPhonePage({ params }: { params: Promise<{ store: string }> }) {
   const { store: storeSlug } = await params

--- a/app/admin/login/admin-login-client.tsx
+++ b/app/admin/login/admin-login-client.tsx
@@ -3,11 +3,12 @@
 /**
  * @design_doc   ui-improvement-instructions.md U-3 false authentication UI removal
  * @related_to   setup-admin.ts: creates admin users without exposing shared demo passwords
- * @known_issues Password visibility toggle is still handled separately from customer auth forms
+ * @known_issues Administrator recovery requires a privileged operator because admin reset tokens are not stored
  */
 import { useState } from 'react'
 import { signIn } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -20,7 +21,7 @@ import {
   CardTitle,
 } from '@/components/ui/card'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { AlertCircle } from 'lucide-react'
+import { AlertCircle, Eye, EyeOff, ShieldCheck } from 'lucide-react'
 
 export function AdminLoginClient() {
   const router = useRouter()
@@ -28,6 +29,7 @@ export function AdminLoginClient() {
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
   const [isLoading, setIsLoading] = useState(false)
+  const [showPassword, setShowPassword] = useState(false)
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -55,11 +57,14 @@ export function AdminLoginClient() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50">
-      <Card className="w-full max-w-md">
-        <CardHeader className="space-y-1">
-          <CardTitle className="text-2xl font-bold">管理者ログイン</CardTitle>
-          <CardDescription>管理画面にアクセスするにはログインしてください</CardDescription>
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-b from-muted/40 to-background px-4">
+      <Card className="w-full max-w-md shadow-xl">
+        <CardHeader className="space-y-3 text-center">
+          <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-primary text-primary-foreground">
+            <ShieldCheck className="h-7 w-7" />
+          </div>
+          <CardTitle className="text-2xl font-bold">GOLD ESTHE GROUP 管理画面</CardTitle>
+          <CardDescription>管理者アカウントでログインしてください</CardDescription>
         </CardHeader>
         <form onSubmit={handleSubmit}>
           <CardContent className="space-y-4">
@@ -75,6 +80,8 @@ export function AdminLoginClient() {
                 id="email"
                 type="email"
                 placeholder="admin@example.com"
+                autoComplete="email"
+                autoFocus
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 required
@@ -82,19 +89,44 @@ export function AdminLoginClient() {
             </div>
             <div className="space-y-2">
               <Label htmlFor="password">パスワード</Label>
-              <Input
-                id="password"
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-              />
+              <div className="relative">
+                <Input
+                  id="password"
+                  type={showPassword ? 'text' : 'password'}
+                  placeholder="パスワード"
+                  autoComplete="current-password"
+                  className="pr-11"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="absolute right-0 top-0 h-10 w-11"
+                  onClick={() => setShowPassword((visible) => !visible)}
+                  aria-label={showPassword ? 'パスワードを隠す' : 'パスワードを表示'}
+                  aria-pressed={showPassword}
+                >
+                  {showPassword ? <EyeOff /> : <Eye />}
+                </Button>
+              </div>
+              <p className="text-right text-xs text-muted-foreground">
+                パスワードをお忘れの方は
+                <Link href="#password-help" className="ml-1 text-primary underline">
+                  管理責任者へ再発行を依頼
+                </Link>
+              </p>
             </div>
           </CardContent>
-          <CardFooter>
+          <CardFooter id="password-help" className="flex-col gap-3">
             <Button type="submit" className="w-full" disabled={isLoading}>
               {isLoading ? 'ログイン中...' : 'ログイン'}
             </Button>
+            <p className="text-center text-xs text-muted-foreground">
+              管理者パスワードは安全上メールで自動再発行されません。店舗の管理責任者へご連絡ください。
+            </p>
           </CardFooter>
         </form>
       </Card>

--- a/app/auth/error/page.tsx
+++ b/app/auth/error/page.tsx
@@ -47,12 +47,10 @@ export default function AuthErrorPage() {
   const errorInfo = errorMessages[error || 'Default'] || errorMessages.Default
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 dark:bg-gray-900 sm:px-6 lg:px-8">
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
-          <CardTitle className="text-2xl font-bold text-red-600 dark:text-red-400">
-            認証エラー
-          </CardTitle>
+          <CardTitle className="text-2xl font-bold text-red-600">認証エラー</CardTitle>
           <CardDescription>ログイン処理中に問題が発生しました</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -72,8 +70,8 @@ export default function AuthErrorPage() {
           </div>
 
           {error && (
-            <div className="mt-4 rounded-md bg-gray-100 p-3 dark:bg-gray-800">
-              <p className="text-xs text-gray-600 dark:text-gray-400">エラーコード: {error}</p>
+            <div className="mt-4 rounded-md bg-gray-100 p-3">
+              <p className="text-xs text-gray-600">エラーコード: {error}</p>
             </div>
           )}
         </CardContent>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,12 @@
-'use client'
-
 /**
- * @design_doc   ui-improvement-instructions.md U-3 portal link label correction
- * @related_to   app/[store]/recruitment/page.tsx: destination is newcomer information
- * @known_issues Real recruitment page remains a product proposal, not implemented here
+ * @design_doc   docs/SYSTEM_AUDIT_2026-07-26.md J-1 and C-13 age-safe group landing
+ * @related_to   AgeVerificationClient: persists first-party age consent
+ * @known_issues Verification is self-attested and does not independently prove identity
  */
-import { useState, useEffect } from 'react'
 import Link from 'next/link'
-import { AgeVerification } from '@/components/age-verification'
+import { cookies } from 'next/headers'
+import { AgeVerificationClient } from '@/components/age-verification-client'
+import { AGE_VERIFICATION_COOKIE, AGE_VERIFICATION_COOKIE_VALUE } from '@/lib/age-verification'
 
 const navigation = [
   { label: 'GOLD ESTHE GROUP 総合TOP', href: '/' },
@@ -15,33 +14,10 @@ const navigation = [
   { label: '新人情報 金の玉クラブ 池袋店', href: '/ikebukuro/recruitment' },
 ]
 
-export default function HomePage() {
-  const [isVerified, setIsVerified] = useState(false)
-  const [isLoading, setIsLoading] = useState(true)
-
-  useEffect(() => {
-    const verified = localStorage.getItem('ageVerified')
-    if (verified === 'true') {
-      setIsVerified(true)
-    }
-    setIsLoading(false)
-  }, [])
-
-  const handleVerification = (isAdult: boolean) => {
-    if (isAdult) {
-      localStorage.setItem('ageVerified', 'true')
-      setIsVerified(true)
-    } else {
-      window.location.href = 'https://www.google.com'
-    }
-  }
-
-  if (isLoading) {
-    return null
-  }
-
-  if (!isVerified) {
-    return <AgeVerification onVerify={handleVerification} />
+export default async function HomePage() {
+  const cookieStore = await cookies()
+  if (cookieStore.get(AGE_VERIFICATION_COOKIE)?.value !== AGE_VERIFICATION_COOKIE_VALUE) {
+    return <AgeVerificationClient callbackUrl="/" />
   }
 
   return (

--- a/components/age-verification-client.tsx
+++ b/components/age-verification-client.tsx
@@ -1,7 +1,7 @@
 /**
  * @design_doc   docs/SYSTEM_AUDIT_2026-07-26.md J-1 storefront age verification
  * @related_to   AgeVerification renders the prompt; age-verification API persists consent
- * @known_issues The underage exit destination remains externally configured in a later phase
+ * @known_issues None
  */
 'use client'
 
@@ -16,10 +16,11 @@ interface AgeVerificationClientProps {
 export function AgeVerificationClient({ callbackUrl }: AgeVerificationClientProps) {
   const router = useRouter()
   const [error, setError] = useState<string | null>(null)
+  const [declined, setDeclined] = useState(false)
 
   const handleVerification = async (isAdult: boolean) => {
     if (!isAdult) {
-      window.location.assign('https://www.google.com')
+      setDeclined(true)
       return
     }
 
@@ -34,6 +35,24 @@ export function AgeVerificationClient({ callbackUrl }: AgeVerificationClientProp
     } catch {
       setError('年齢確認を保存できませんでした。もう一度お試しください。')
     }
+  }
+
+  if (declined) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-luxury-black-deep px-4 text-center text-luxury-gold-soft">
+        <div className="max-w-md space-y-4 rounded-lg border border-luxury-gold-border/40 bg-luxury-panel-dark p-8">
+          <h1 className="text-xl font-semibold text-luxury-gold">ご利用いただけません</h1>
+          <p>18歳未満および高校生の方はご利用いただけません。</p>
+          <button
+            type="button"
+            className="min-h-11 rounded-md border border-luxury-gold-border/60 px-5"
+            onClick={() => setDeclined(false)}
+          >
+            年齢確認に戻る
+          </button>
+        </div>
+      </main>
+    )
   }
 
   return <AgeVerification onVerify={handleVerification} error={error} />

--- a/components/age-verification.tsx
+++ b/components/age-verification.tsx
@@ -11,16 +11,16 @@ interface AgeVerificationProps {
 
 export function AgeVerification({ onVerify, error }: AgeVerificationProps) {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-100">
-      <Card className="w-full max-w-md">
+    <div className="luxury-body flex min-h-screen items-center justify-center bg-luxury-black-deep px-4 text-luxury-gold-soft">
+      <Card className="luxury-panel w-full max-w-md">
         <CardHeader className="text-center">
           <div className="mb-4 flex justify-center">
-            <Shield className="h-12 w-12 text-gray-700" />
+            <Shield className="h-12 w-12 text-luxury-gold" />
           </div>
           <CardTitle className="text-2xl font-bold">年齢確認</CardTitle>
         </CardHeader>
         <CardContent className="space-y-6">
-          <div className="text-center text-gray-600">
+          <div className="text-center text-luxury-gold-muted">
             <p className="mb-2">当サイトは18歳未満の方の</p>
             <p>ご利用をお断りしております。</p>
           </div>
@@ -40,7 +40,7 @@ export function AgeVerification({ onVerify, error }: AgeVerificationProps) {
             </p>
           ) : null}
 
-          <p className="text-center text-xs text-gray-500">
+          <p className="text-center text-xs text-luxury-gold-muted">
             年齢を偽った場合、法的措置を取る場合があります。
           </p>
         </CardContent>

--- a/components/analytics/cast-performance-table.tsx
+++ b/components/analytics/cast-performance-table.tsx
@@ -131,7 +131,7 @@ export function CastPerformanceTable({
       : 0
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 overflow-x-auto">
       {/* サマリーカード */}
       <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
         <Card>

--- a/components/analytics/daily-report-table.tsx
+++ b/components/analytics/daily-report-table.tsx
@@ -25,11 +25,13 @@ export function DailyReportTable({ report }: DailyReportTableProps) {
   )
 
   return (
-    <DataTable
-      title={`日報: ${report.date}`}
-      summary={summary}
-      data={report.staffReports}
-      columns={columns}
-    />
+    <div className="overflow-x-auto">
+      <DataTable
+        title={`日報: ${report.date}`}
+        summary={summary}
+        data={report.staffReports}
+        columns={columns}
+      />
+    </div>
   )
 }

--- a/components/analytics/print-button.tsx
+++ b/components/analytics/print-button.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+/**
+ * @design_doc   docs/SYSTEM_AUDIT_2026-07-26.md C-7 and C-14 print action consistency
+ * @related_to   analytics report pages and the global print stylesheet
+ * @known_issues Browser print destination and paper size remain user-controlled
+ */
+import { Printer } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+interface PrintButtonProps {
+  onClick: () => void
+}
+
+export function PrintButton({ onClick }: PrintButtonProps) {
+  return (
+    <Button type="button" variant="default" className="print-hidden" onClick={onClick}>
+      <Printer className="mr-2 h-4 w-4" />
+      印刷する
+    </Button>
+  )
+}

--- a/components/analytics/staff-attendance-table.tsx
+++ b/components/analytics/staff-attendance-table.tsx
@@ -66,7 +66,7 @@ export function StaffAttendanceTable({ year, month, data }: StaffAttendanceTable
     .slice(0, 3)
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 overflow-x-auto">
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
         <Card>
           <CardContent className="p-4">

--- a/components/auth/role-guard.tsx
+++ b/components/auth/role-guard.tsx
@@ -7,6 +7,7 @@
 
 import { ReactNode } from 'react'
 import { useSession } from 'next-auth/react'
+import { PageLoading } from '@/components/ui/page-loading'
 
 interface RoleGuardProps {
   children: ReactNode
@@ -25,7 +26,7 @@ export function RoleGuard({
 
   // Show loading state
   if (status === 'loading') {
-    return <div className="animate-pulse">Loading...</div>
+    return <PageLoading compact label="認証情報を確認しています" />
   }
 
   // Check authentication requirement

--- a/components/campaign-banner-slider.tsx
+++ b/components/campaign-banner-slider.tsx
@@ -133,14 +133,14 @@ export function CampaignBannerSlider({
             <>
               <button
                 onClick={goToPrevious}
-                className="absolute left-4 top-1/2 -translate-y-1/2 rounded-full border border-luxury-gold-border/60 bg-black/60 p-2 text-luxury-gold backdrop-blur-sm transition-colors hover:bg-black/80"
+                className="absolute left-4 top-1/2 flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full border border-luxury-gold-border/60 bg-black/60 text-luxury-gold backdrop-blur-sm transition-colors hover:bg-black/80"
                 aria-label="前のバナーへ"
               >
                 <ChevronLeft className="h-5 w-5" />
               </button>
               <button
                 onClick={goToNext}
-                className="absolute right-4 top-1/2 -translate-y-1/2 rounded-full border border-luxury-gold-border/60 bg-black/60 p-2 text-luxury-gold backdrop-blur-sm transition-colors hover:bg-black/80"
+                className="absolute right-4 top-1/2 flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full border border-luxury-gold-border/60 bg-black/60 text-luxury-gold backdrop-blur-sm transition-colors hover:bg-black/80"
                 aria-label="次のバナーへ"
               >
                 <ChevronRight className="h-5 w-5" />
@@ -156,10 +156,10 @@ export function CampaignBannerSlider({
               <button
                 key={index}
                 onClick={() => goToSlide(index)}
-                className={`h-3 w-3 rounded-full transition-all ${
+                className={`flex h-11 w-11 items-center justify-center rounded-full transition-all after:h-3 after:rounded-full after:content-[''] ${
                   index === currentIndex
-                    ? 'w-9 bg-luxury-gold'
-                    : 'bg-luxury-gold/40 hover:bg-luxury-gold/70'
+                    ? 'after:w-9 after:bg-luxury-gold'
+                    : 'after:w-3 after:bg-luxury-gold/40 hover:after:bg-luxury-gold/70'
                 }`}
                 aria-label={`${index + 1}枚目のバナーへ`}
               />

--- a/components/cast-schedule/schedule-edit-dialog.tsx
+++ b/components/cast-schedule/schedule-edit-dialog.tsx
@@ -26,6 +26,8 @@ import {
   type BusinessHoursRange,
   formatMinutesAsLabel,
 } from '@/lib/settings/business-hours'
+import { toast } from '@/hooks/use-toast'
+import { findScheduleValidationError } from '@/lib/cast-schedule/validation'
 
 export interface DaySchedule {
   date: string // yyyy-mm-dd format
@@ -152,31 +154,20 @@ export function ScheduleEditDialog({
   }
 
   const handleSave = () => {
-    // Validate schedule before saving
-    const validatedSchedule: WeeklyScheduleEdit = {}
-
-    for (const [dateKey, daySchedule] of Object.entries(schedule)) {
-      if (daySchedule.status === '出勤予定') {
-        if (!daySchedule.startTime || !daySchedule.endTime) {
-          const dateInJst = zonedTimeToUtc(`${dateKey}T00:00:00`, timeZone)
-          alert(
-            `${formatInTimeZone(dateInJst, timeZone, 'M月d日(E)', { locale: ja })} の時間を入力してください`
-          )
-          return
-        }
-
-        if (daySchedule.startTime >= daySchedule.endTime) {
-          const dateInJst = zonedTimeToUtc(`${dateKey}T00:00:00`, timeZone)
-          alert(
-            `${formatInTimeZone(dateInJst, timeZone, 'M月d日(E)', { locale: ja })} の終了時間は開始時間より後にしてください`
-          )
-          return
-        }
-      }
-
-      validatedSchedule[dateKey] = daySchedule
+    const validationError = findScheduleValidationError(schedule, ['出勤予定'], (dateKey) => {
+      const dateInJst = zonedTimeToUtc(`${dateKey}T00:00:00`, timeZone)
+      return formatInTimeZone(dateInJst, timeZone, 'M月d日(E)', { locale: ja })
+    })
+    if (validationError) {
+      toast({
+        title: '入力内容を確認してください',
+        description: validationError,
+        variant: 'destructive',
+      })
+      return
     }
 
+    const validatedSchedule: WeeklyScheduleEdit = { ...schedule }
     onSave(castId, validatedSchedule)
     onOpenChange(false)
   }

--- a/components/cast/cast-form.tsx
+++ b/components/cast/cast-form.tsx
@@ -28,6 +28,7 @@ import { FormSection } from '@/components/cast/form-section'
 import { cn } from '@/lib/utils'
 import { usePricing } from '@/hooks/use-pricing'
 import { resolveOptionId } from '@/lib/options/data'
+import { useUnsavedChangesWarning } from '@/hooks/use-unsaved-changes-warning'
 
 type OptionChoice = {
   id: string
@@ -239,6 +240,7 @@ export function CastForm({
   isSubmitting = false,
 }: CastFormProps) {
   const [formData, setFormData] = useState(() => buildInitialFormState(cast))
+  const initialFormData = useMemo(() => buildInitialFormState(cast), [cast])
   const [showLoginPassword, setShowLoginPassword] = useState(false)
   const [showLoginPasswordConfirm, setShowLoginPasswordConfirm] = useState(false)
   const {
@@ -248,6 +250,11 @@ export function CastForm({
   } = useForm<CastFormValidationValues>()
   const fieldId = (suffix: string) => `cast-${suffix}`
   const { optionPrices, options: legacyOptions, loading: optionsLoading } = usePricing(storeId)
+  const isDirty = useMemo(
+    () => JSON.stringify(formData) !== JSON.stringify(initialFormData),
+    [formData, initialFormData]
+  )
+  useUnsavedChangesWarning(isDirty && !isSubmitting)
 
   const optionCatalog: OptionChoice[] = useMemo(() => {
     if (optionPrices.length > 0) {
@@ -550,6 +557,7 @@ export function CastForm({
               value={formData.name}
               onChange={handleInputChange}
               placeholder="例：高橋 えみり"
+              autoFocus
               required
               aria-required="true"
               aria-invalid={Boolean(errors.name)}

--- a/components/cast/cast-line-registration-panel.test.tsx
+++ b/components/cast/cast-line-registration-panel.test.tsx
@@ -40,8 +40,7 @@ describe('CastLineRegistrationPanel', () => {
   })
 
   it('revokes pending tokens while unlinking an existing account', async () => {
-    const user = userEvent.setup()
-    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const user = userEvent.setup({ pointerEventsCheck: 0 })
     vi.mocked(fetch).mockResolvedValueOnce(
       new Response(JSON.stringify({ success: true }), {
         status: 200,
@@ -53,6 +52,8 @@ describe('CastLineRegistrationPanel', () => {
 
     expect(screen.getByText('LINE連携済み')).toBeInTheDocument()
     await user.click(screen.getByRole('button', { name: 'LINE連携を解除' }))
+    expect(fetch).not.toHaveBeenCalled()
+    await user.click(screen.getByRole('button', { name: '連携を解除' }))
 
     expect(fetch).toHaveBeenCalledWith('/api/cast/line-registration-token?storeId=store-a', {
       method: 'DELETE',

--- a/components/cast/cast-line-registration-panel.tsx
+++ b/components/cast/cast-line-registration-panel.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from 'react'
 import { Check, Copy, KeyRound, Unlink } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/shared/confirm-dialog'
 
 interface CastLineRegistrationPanelProps {
   castId: string
@@ -81,10 +82,6 @@ export function CastLineRegistrationPanel({
   }
 
   const unlinkAccount = async () => {
-    if (!window.confirm('LINE連携を解除します。発行済みの招待コマンドも無効になります。')) {
-      return
-    }
-
     setIsUnlinking(true)
     setError(null)
     try {
@@ -122,10 +119,17 @@ export function CastLineRegistrationPanel({
         {linked ? (
           <div className="flex flex-col items-start gap-3">
             <p className="text-sm font-medium text-emerald-700">LINE連携済み</p>
-            <Button type="button" variant="outline" onClick={unlinkAccount} disabled={isUnlinking}>
-              <Unlink className="mr-2 h-4 w-4" />
-              {isUnlinking ? '解除中...' : 'LINE連携を解除'}
-            </Button>
+            <ConfirmDialog
+              title="LINE連携を解除しますか？"
+              description="発行済みの招待コマンドも無効になります。この操作は元に戻せません。"
+              confirmLabel="連携を解除"
+              onConfirm={unlinkAccount}
+            >
+              <Button type="button" variant="outline" disabled={isUnlinking}>
+                <Unlink className="mr-2 h-4 w-4" />
+                {isUnlinking ? '解除中...' : 'LINE連携を解除'}
+              </Button>
+            </ConfirmDialog>
           </div>
         ) : (
           <Button type="button" onClick={issueCommand} disabled={isIssuing}>

--- a/components/cast/schedule-edit-dialog.tsx
+++ b/components/cast/schedule-edit-dialog.tsx
@@ -31,6 +31,8 @@ import {
   type BusinessHoursRange,
   formatMinutesAsLabel,
 } from '@/lib/settings/business-hours'
+import { toast } from '@/hooks/use-toast'
+import { findScheduleValidationError } from '@/lib/cast-schedule/validation'
 
 export type WorkStatus = '休日' | '出勤予定' | '未入力' | '出勤中' | '早退' | '遅刻'
 
@@ -156,29 +158,21 @@ export function ScheduleEditDialog({
   }
 
   const handleSave = () => {
-    // Validate schedule before saving
-    const validatedSchedule: WeeklySchedule = {}
-
-    for (const [dateKey, daySchedule] of Object.entries(schedule)) {
-      if (daySchedule.status === '出勤予定' || daySchedule.status === '出勤中') {
-        if (!daySchedule.startTime || !daySchedule.endTime) {
-          alert(
-            `${format(new Date(dateKey), 'M月d日(E)', { locale: ja })} の時間を入力してください`
-          )
-          return
-        }
-
-        if (daySchedule.startTime >= daySchedule.endTime) {
-          alert(
-            `${format(new Date(dateKey), 'M月d日(E)', { locale: ja })} の終了時間は開始時間より後にしてください`
-          )
-          return
-        }
-      }
-
-      validatedSchedule[dateKey] = daySchedule
+    const validationError = findScheduleValidationError(
+      schedule,
+      ['出勤予定', '出勤中'],
+      (dateKey) => format(new Date(dateKey), 'M月d日(E)', { locale: ja })
+    )
+    if (validationError) {
+      toast({
+        title: '入力内容を確認してください',
+        description: validationError,
+        variant: 'destructive',
+      })
+      return
     }
 
+    const validatedSchedule: WeeklySchedule = { ...schedule }
     const result = onSave(validatedSchedule)
     setSchedule(validatedSchedule)
 

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -138,7 +138,7 @@ export function Header() {
 
   return (
     <>
-      <div className="fixed left-0 right-0 top-0 z-50 flex items-center gap-4 border-b bg-white p-4 shadow-sm">
+      <div className="print-hidden sticky top-0 z-50 flex items-center gap-4 border-b bg-background p-4 shadow-sm">
         <Sheet>
           <SheetTrigger asChild>
             <Button variant="outline" size="icon" className="xl:hidden" aria-label="メニューを開く">
@@ -150,6 +150,26 @@ export function Header() {
               <SheetTitle>管理メニュー</SheetTitle>
             </SheetHeader>
             <nav className="mt-6 grid gap-2">
+              <Button
+                type="button"
+                variant="secondary"
+                className="min-h-11 justify-start"
+                onClick={() => setShowCustomerSelection(true)}
+                aria-label="モバイル予約作成"
+              >
+                <Calendar className="mr-3 h-4 w-4" />
+                予約作成
+              </Button>
+              <Button
+                type="button"
+                variant="secondary"
+                className="min-h-11 justify-start"
+                onClick={() => setShowCustomerLookup(true)}
+                aria-label="モバイル顧客検索"
+              >
+                <Search className="mr-3 h-4 w-4" />
+                顧客検索
+              </Button>
               {adminNavigationLinks.map((item) => (
                 <Link
                   key={item.href}

--- a/components/store-footer.tsx
+++ b/components/store-footer.tsx
@@ -42,7 +42,10 @@ export function StoreFooter({ store }: StoreFooterProps) {
           {/* Phone Number */}
           <div className="flex items-center justify-center gap-2 text-2xl font-bold md:text-3xl">
             <Phone className="h-6 w-6 text-[#f3d08a] md:h-8 md:w-8" />
-            <a href={`tel:${store.phone}`} className="transition-colors hover:text-[#f6d48a]">
+            <a
+              href={`tel:${store.phone}`}
+              className="flex min-h-11 items-center transition-colors hover:text-[#f6d48a]"
+            >
               ({store.phone})
             </a>
           </div>
@@ -59,7 +62,7 @@ export function StoreFooter({ store }: StoreFooterProps) {
               <a
                 key={social.name}
                 href={social.href}
-                className="text-[#cbb88f] transition-colors hover:text-[#f6d48a]"
+                className="flex h-11 w-11 items-center justify-center text-[#cbb88f] transition-colors hover:text-[#f6d48a]"
                 aria-label={social.name}
               >
                 <social.icon className="h-8 w-8" />

--- a/components/store-navigation.tsx
+++ b/components/store-navigation.tsx
@@ -50,13 +50,13 @@ export function StoreNavigation() {
           </Link>
 
           {/* Desktop Navigation */}
-          <nav className="hidden items-center gap-5 lg:flex">
+          <nav className="hidden items-center gap-3 xl:flex 2xl:gap-5">
             {navigationItems.map((item) => (
               <Link
                 key={item.href}
                 href={`/${store.slug}${item.href}`}
                 className={cn(
-                  'text-xs font-semibold tracking-[0.2em] text-luxury-gold-soft transition-colors hover:text-luxury-gold-bright',
+                  'whitespace-nowrap text-xs font-semibold tracking-[0.12em] text-luxury-gold-soft transition-colors hover:text-luxury-gold-bright 2xl:tracking-[0.2em]',
                   pathname === `/${store.slug}${item.href}`
                     ? 'text-luxury-gold-bright'
                     : 'text-luxury-gold-muted'
@@ -122,7 +122,15 @@ export function StoreNavigation() {
             </>
           )}
 
-          <div className="hidden flex-col items-end text-xs text-luxury-gold-muted sm:flex">
+          <a
+            href={`tel:${store.phone}`}
+            className="flex min-h-11 min-w-11 items-center justify-center rounded-md border border-luxury-gold-border/50 text-luxury-gold sm:hidden"
+            aria-label={`電話で問い合わせ ${store.phone}`}
+          >
+            <Phone className="h-5 w-5" />
+          </a>
+
+          <div className="hidden flex-col items-end text-xs text-luxury-gold-muted md:flex">
             <a
               href={`tel:${store.phone}`}
               className="flex items-center gap-2 text-base font-semibold text-luxury-gold transition-colors hover:text-[#f8e2b5]"
@@ -138,12 +146,12 @@ export function StoreNavigation() {
 
           {/* Mobile Menu */}
           <Sheet>
-            <SheetTrigger asChild className="lg:hidden">
+            <SheetTrigger asChild className="xl:hidden">
               <Button
                 variant="ghost"
                 size="icon"
                 aria-label="店舗メニューを開く"
-                className="border border-luxury-gold-border/50 text-luxury-gold hover:bg-luxury-brown-muted"
+                className="h-11 w-11 border border-luxury-gold-border/50 text-luxury-gold hover:bg-luxury-brown-muted"
               >
                 <Menu className="h-5 w-5" />
               </Button>
@@ -161,7 +169,7 @@ export function StoreNavigation() {
                     key={item.href}
                     href={`/${store.slug}${item.href}`}
                     className={cn(
-                      'py-2 text-sm font-medium text-luxury-gold-menu transition-colors hover:text-luxury-gold-bright',
+                      'flex min-h-11 items-center py-2 text-sm font-medium text-luxury-gold-menu transition-colors hover:text-luxury-gold-bright',
                       pathname === `/${store.slug}${item.href}`
                         ? 'text-luxury-gold-bright'
                         : 'text-luxury-gold-muted'
@@ -173,7 +181,7 @@ export function StoreNavigation() {
                 <div className="rounded-md border border-luxury-gold-border/35 bg-[#1b1510] p-4">
                   <a
                     href={`tel:${store.phone}`}
-                    className="flex items-center gap-2 text-base font-semibold text-luxury-gold transition-colors hover:text-[#f8e2b5]"
+                    className="flex min-h-11 items-center gap-2 text-base font-semibold text-luxury-gold transition-colors hover:text-[#f8e2b5]"
                     aria-label={`電話で問い合わせ ${store.phone}`}
                   >
                     <Phone className="h-4 w-4" />

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,8 +1,0 @@
-'use client'
-
-import * as React from 'react'
-import { ThemeProvider as NextThemesProvider, type ThemeProviderProps } from 'next-themes'
-
-export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
-}

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -9,8 +9,7 @@ const alertVariants = cva(
     variants: {
       variant: {
         default: 'bg-background text-foreground',
-        destructive:
-          'border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive',
+        destructive: 'border-destructive/50 text-destructive [&>svg]:text-destructive',
       },
     },
     defaultVariants: {

--- a/components/ui/page-loading.tsx
+++ b/components/ui/page-loading.tsx
@@ -1,0 +1,64 @@
+/**
+ * @design_doc   docs/SYSTEM_AUDIT_2026-07-26.md C-4 shared loading states
+ * @related_to   Skeleton: shared visual placeholder; route loading boundaries
+ * @known_issues Callers choose a page-level or compact presentation
+ */
+import { Loader2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Skeleton } from '@/components/ui/skeleton'
+
+interface PageLoadingProps {
+  label?: string
+  compact?: boolean
+  className?: string
+}
+
+export function PageLoading({
+  label = '読み込んでいます',
+  compact = false,
+  className,
+}: PageLoadingProps) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        'flex items-center justify-center gap-3 text-sm text-muted-foreground',
+        compact ? 'min-h-24' : 'min-h-[40vh]',
+        className
+      )}
+    >
+      <Loader2 className="h-5 w-5 animate-spin" aria-hidden="true" />
+      <span>{label}</span>
+    </div>
+  )
+}
+
+interface TableSkeletonProps {
+  rows?: number
+  columns?: number
+  label?: string
+}
+
+export function TableSkeleton({
+  rows = 5,
+  columns = 4,
+  label = '一覧を読み込んでいます',
+}: TableSkeletonProps) {
+  return (
+    <div role="status" aria-label={label} className="space-y-3">
+      {Array.from({ length: rows }, (_, row) => (
+        <div
+          key={row}
+          className="grid gap-3"
+          style={{ gridTemplateColumns: `repeat(${columns}, 1fr)` }}
+        >
+          {Array.from({ length: columns }, (_, column) => (
+            <Skeleton key={column} className="h-10 w-full" />
+          ))}
+        </div>
+      ))}
+      <span className="sr-only">{label}</span>
+    </div>
+  )
+}

--- a/docs/UX_FOUNDATIONS.md
+++ b/docs/UX_FOUNDATIONS.md
@@ -1,0 +1,27 @@
+# UX foundations
+
+This document records the cross-application UI decisions made while resolving the 2026-07-26
+system audit.
+
+## Theme strategy
+
+- The admin application uses the shadcn semantic tokens defined in `styles/globals.css`.
+- Public storefront routes apply their black-and-gold token values in `app/[store]/layout.tsx`.
+- Runtime theme switching is intentionally unsupported. The unused `next-themes` dependency,
+  provider, `.dark` variables, and `dark:` variants were removed.
+- Shared components must use semantic tokens. Storefront-only components may use the documented
+  `luxury-*` palette.
+
+## Shared interaction patterns
+
+- `PageLoading` is the page or permission-boundary loading state.
+- `TableSkeleton` is the loading state for administrative lists.
+- Destructive actions use `ConfirmDialog`; validation feedback uses the toast system.
+- Header and navigation actions must provide a minimum 44px touch target.
+- Long administrative forms use `useUnsavedChangesWarning` where losing edits would be costly.
+
+## Printing
+
+Global print rules hide elements marked `print-hidden`, buttons, and popover content; remove sticky
+positioning; and avoid breaking rows, images, and cards across pages. Analytics screens use the
+shared `PrintButton` so future print behavior can be updated in one place.

--- a/hooks/use-unsaved-changes-warning.ts
+++ b/hooks/use-unsaved-changes-warning.ts
@@ -1,0 +1,26 @@
+'use client'
+
+/**
+ * @design_doc   docs/SYSTEM_AUDIT_2026-07-26.md K-4 unsaved form protection
+ * @related_to   CastForm and other long-running administrative forms
+ * @known_issues Client-side route transitions need an in-app confirmation dialog per form
+ */
+import { useEffect } from 'react'
+
+export function useUnsavedChangesWarning(isDirty: boolean): void {
+  useEffect(() => {
+    if (!isDirty) {
+      return
+    }
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault()
+      event.returnValue = ''
+    }
+
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload)
+    }
+  }, [isDirty])
+}

--- a/lib/cast-schedule/validation.test.ts
+++ b/lib/cast-schedule/validation.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @design_doc   docs/SYSTEM_AUDIT_2026-07-26.md C-5 schedule editor consolidation
+ * @related_to   findScheduleValidationError shared by both schedule editors
+ * @known_issues None
+ */
+import { describe, expect, it } from 'vitest'
+import { findScheduleValidationError } from './validation'
+
+describe('findScheduleValidationError', () => {
+  const formatDate = (dateKey: string) => `[${dateKey}]`
+
+  it('requires both times on a working day', () => {
+    expect(
+      findScheduleValidationError(
+        { '2026-07-27': { status: '出勤予定', startTime: '10:00' } },
+        ['出勤予定'],
+        formatDate
+      )
+    ).toBe('[2026-07-27] の時間を入力してください')
+  })
+
+  it('requires the end time to follow the start time', () => {
+    expect(
+      findScheduleValidationError(
+        {
+          '2026-07-27': {
+            status: '出勤予定',
+            startTime: '18:00',
+            endTime: '12:00',
+          },
+        },
+        ['出勤予定'],
+        formatDate
+      )
+    ).toBe('[2026-07-27] の終了時間は開始時間より後にしてください')
+  })
+
+  it('ignores non-working days and accepts valid working times', () => {
+    expect(
+      findScheduleValidationError(
+        {
+          '2026-07-27': { status: '休日' },
+          '2026-07-28': {
+            status: '出勤予定',
+            startTime: '10:00',
+            endTime: '18:00',
+          },
+        },
+        ['出勤予定'],
+        formatDate
+      )
+    ).toBeNull()
+  })
+})

--- a/lib/cast-schedule/validation.ts
+++ b/lib/cast-schedule/validation.ts
@@ -1,0 +1,29 @@
+/**
+ * @design_doc   docs/SYSTEM_AUDIT_2026-07-26.md C-5 schedule editor consolidation
+ * @related_to   Both administrative weekly schedule editor presentations
+ * @known_issues Presentation-specific status choices remain owned by each editor
+ */
+interface ScheduleTimeEntry {
+  status: string
+  startTime?: string
+  endTime?: string
+}
+
+export function findScheduleValidationError(
+  schedule: Record<string, ScheduleTimeEntry>,
+  workingStatuses: readonly string[],
+  formatDate: (dateKey: string) => string
+): string | null {
+  for (const [dateKey, entry] of Object.entries(schedule)) {
+    if (!workingStatuses.includes(entry.status)) {
+      continue
+    }
+    if (!entry.startTime || !entry.endTime) {
+      return `${formatDate(dateKey)} の時間を入力してください`
+    }
+    if (entry.startTime >= entry.endTime) {
+      return `${formatDate(dateKey)} の終了時間は開始時間より後にしてください`
+    }
+  }
+  return null
+}

--- a/lib/store/public-fallbacks.ts
+++ b/lib/store/public-fallbacks.ts
@@ -124,9 +124,9 @@ const FALLBACK_NEWCOMERS = [
     sizeLabel: 'T157 B84(E) W57 H83',
   }),
   createCastSummary({
-    name: 'ことね',
-    age: 27,
-    sizeLabel: 'T158 B95(G) W63 H97',
+    name: 'あかり',
+    age: 25,
+    sizeLabel: 'T159 B86(E) W59 H87',
   }),
 ]
 
@@ -151,9 +151,9 @@ const FALLBACK_SCHEDULE = [
   ),
   createScheduleSummary(
     createCastSummary({
-      name: 'すずか',
-      age: 29,
-      sizeLabel: 'T155 B93(F) W58 H90',
+      name: 'かな',
+      age: 26,
+      sizeLabel: 'T158 B88(F) W60 H89',
     }),
     '2024-06-08T14:00:00+09:00',
     '2024-06-08T22:00:00+09:00'
@@ -172,9 +172,9 @@ const FALLBACK_SCHEDULE = [
 const FALLBACK_REVIEWS: PublicReviewSummary[] = [
   {
     id: 'fallback-review-1',
-    castId: 'suzuka',
-    castName: 'すずか',
-    rating: 5,
+    castId: 'nonoka',
+    castName: 'ののか',
+    rating: 4,
     comment:
       '容姿もとても綺麗でスタイルも抜群でした！密着も素晴らしかったですし、マッサージもすごくよかったです！',
     createdAt: '2024-06-08T21:12:00+09:00',

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "lucide-react": "^0.454.0",
     "next": "^15.2.8",
     "next-auth": "^4.24.11",
-    "next-themes": "^0.4.4",
     "pino": "^9.7.0",
     "pino-pretty": "^13.0.0",
     "prisma": "^6.11.1",

--- a/phase3-ux-foundation.test.ts
+++ b/phase3-ux-foundation.test.ts
@@ -1,0 +1,166 @@
+/**
+ * @design_doc   docs/SYSTEM_AUDIT_2026-07-26.md C-1 through C-14, J-5 through J-13
+ * @related_to   StoreNavigation, Header, PageLoading, ConfirmDialog: shared UX foundations
+ * @known_issues Visual breakpoint behavior is additionally covered by Playwright in phase 4
+ */
+import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (path: string) => readFile(resolve(process.cwd(), path), 'utf8')
+
+describe('phase 3 UX foundation contracts', () => {
+  it('keeps public navigation labels intact and exposes mobile phone actions', async () => {
+    const navigation = await read('components/store-navigation.tsx')
+
+    expect(navigation).toContain('whitespace-nowrap')
+    expect(navigation).toContain('sm:hidden')
+    expect(navigation).toContain(`href={\`tel:\${store.phone}\`}`)
+    expect(navigation).toContain('min-h-11')
+  })
+
+  it('uses normal-flow admin navigation and exposes primary mobile actions', async () => {
+    const header = await read('components/header.tsx')
+    const layout = await read('app/(admin)/admin-layout-client.tsx')
+
+    expect(header).toContain('sticky')
+    expect(header).not.toContain('fixed left-0 right-0 top-0')
+    expect(header).toContain('モバイル予約作成')
+    expect(header).toContain('モバイル顧客検索')
+    expect(layout).not.toContain('pt-[83px]')
+    expect(layout).toContain('<PageLoading')
+    expect(layout).not.toContain('Loading...')
+  })
+
+  it.each([
+    'app/(admin)/admin/customers/page.tsx',
+    'app/(admin)/admin/reservation-list/page.tsx',
+    'app/(admin)/admin/cast/list/page.tsx',
+    'app/(admin)/admin/reviews/page.tsx',
+  ])('uses the shared table loading state in %s', async (path) => {
+    expect(await read(path)).toContain('<TableSkeleton')
+  })
+
+  it('provides horizontally scrollable data tables', async () => {
+    const paths = [
+      'components/analytics/cast-performance-table.tsx',
+      'components/analytics/daily-report-table.tsx',
+      'components/analytics/staff-attendance-table.tsx',
+      'components/store-schedule-content.tsx',
+    ]
+
+    for (const path of paths) {
+      expect(await read(path)).toContain('overflow-x-auto')
+    }
+  })
+
+  it('removes native browser dialogs from product interactions', async () => {
+    const paths = [
+      'components/cast-schedule/schedule-edit-dialog.tsx',
+      'components/cast/schedule-edit-dialog.tsx',
+      'components/cast/cast-line-registration-panel.tsx',
+    ]
+
+    for (const path of paths) {
+      const source = await read(path)
+      expect(source).not.toMatch(/\b(?:window\.)?(?:alert|confirm)\s*\(/)
+    }
+    const legacyEditor = await read('components/cast-schedule/schedule-edit-dialog.tsx')
+    const currentEditor = await read('components/cast/schedule-edit-dialog.tsx')
+    expect(legacyEditor).toContain('findScheduleValidationError')
+    expect(currentEditor).toContain('findScheduleValidationError')
+  })
+
+  it('uses one explicit theme strategy and print foundation', async () => {
+    const packageJson = await read('package.json')
+    const globalStyles = await read('styles/globals.css')
+    const tailwindConfig = await read('tailwind.config.ts')
+    const authError = await read('app/auth/error/page.tsx')
+    const alert = await read('components/ui/alert.tsx')
+
+    expect(packageJson).not.toContain('"next-themes"')
+    expect(existsSync(resolve(process.cwd(), 'components/theme-provider.tsx'))).toBe(false)
+    expect(globalStyles).not.toContain('.dark {')
+    expect(tailwindConfig).not.toContain('darkMode')
+    expect(authError).not.toContain('dark:')
+    expect(alert).not.toContain('dark:')
+    expect(globalStyles).toContain('@media print')
+    expect(globalStyles).toContain('.print-hidden')
+  })
+
+  it('does not duplicate customer login headings and improves admin login access', async () => {
+    const customerLogin = await read('app/[store]/login/page.tsx')
+    const adminLogin = await read('app/admin/login/admin-login-client.tsx')
+
+    expect(customerLogin).not.toContain('<h1')
+    expect(adminLogin).toContain('autoFocus')
+    expect(adminLogin).toContain('current-password')
+    expect(adminLogin).toContain('パスワードをお忘れの方')
+    expect(adminLogin).toContain('パスワードを表示')
+  })
+
+  it('keeps an underage visitor on an explanatory first-party screen', async () => {
+    const gate = await read('components/age-verification-client.tsx')
+
+    expect(gate).not.toContain('google.com')
+    expect(gate).toContain('18歳未満および高校生の方はご利用いただけません')
+  })
+
+  it.each([
+    ['services', 'プレイ内容'],
+    ['ranking', 'ランキング'],
+    ['recruitment', '入店情報'],
+    ['forgot-password', 'パスワード再設定'],
+    ['mypage', 'マイページ'],
+    ['verify-phone', '電話番号認証'],
+  ])('uses the store title template for %s', async (route, title) => {
+    const source = await read(`app/[store]/${route}/page.tsx`)
+
+    expect(source).toContain(`title: '${title}'`)
+  })
+
+  it('keeps fallback storefront data plausible for demos', async () => {
+    const source = await read('lib/store/public-fallbacks.ts')
+    const newcomers = source.match(/const FALLBACK_NEWCOMERS = \[[\s\S]*?\n\]/)?.[0] ?? ''
+    const reviews = source.match(/const FALLBACK_REVIEWS:[\s\S]*?\n\]/)?.[0] ?? ''
+
+    expect(newcomers).not.toContain("name: 'ことね'")
+    expect(reviews.match(/castName: 'すずか'/g)).toHaveLength(1)
+    expect(reviews).toContain('rating: 4')
+  })
+
+  it('shares semantic print actions instead of repeating palette utilities', async () => {
+    const printButton = await read('components/analytics/print-button.tsx')
+    const routes = [
+      'annual-sales',
+      'area-sales',
+      'cast-performance',
+      'course-sales',
+      'district-sales',
+      'hourly-sales',
+      'marketing-channels',
+      'monthly-sales',
+      'option-sales',
+      'staff-attendance',
+    ]
+
+    expect(printButton).toContain('variant="default"')
+    expect(printButton).toContain('print-hidden')
+    for (const route of routes) {
+      const source = await read(`app/(admin)/admin/analytics/${route}/page.tsx`)
+      expect(source).toContain('<PrintButton')
+      expect(source).not.toContain('bg-emerald-600 text-white hover:bg-emerald-700')
+    }
+  })
+
+  it('protects the primary long form from accidental loss and establishes focus', async () => {
+    const hook = await read('hooks/use-unsaved-changes-warning.ts')
+    const castForm = await read('components/cast/cast-form.tsx')
+
+    expect(hook).toContain("addEventListener('beforeunload'")
+    expect(hook).toContain('event.preventDefault()')
+    expect(castForm).toContain('useUnsavedChangesWarning')
+    expect(castForm).toContain('autoFocus')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,9 +139,6 @@ importers:
       next-auth:
         specifier: ^4.24.11
         version: 4.24.11(next@15.5.12(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      next-themes:
-        specifier: ^0.4.4
-        version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       pino:
         specifier: ^9.7.0
         version: 9.7.0
@@ -5425,15 +5422,6 @@ packages:
       nodemailer:
         optional: true
 
-  next-themes@0.4.6:
-    resolution:
-      {
-        integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==,
-      }
-    peerDependencies:
-      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
-
   next@15.5.12:
     resolution:
       {
@@ -10543,11 +10531,6 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       uuid: 8.3.2
-
-  next-themes@0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
 
   next@15.5.12(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -142,40 +142,6 @@ body {
     --sidebar-border: 220 13% 91%;
     --sidebar-ring: 217.2 91.2% 59.8%;
   }
-  .dark {
-    --background: 0 0% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 0 0% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 0 0% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 0 0% 9%;
-    --secondary: 0 0% 14.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
-    --accent: 0 0% 14.9%;
-    --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
-    --ring: 0 0% 83.1%;
-    --chart-1: 220 70% 50%;
-    --chart-2: 160 60% 45%;
-    --chart-3: 30 80% 55%;
-    --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%;
-    --sidebar-background: 240 5.9% 10%;
-    --sidebar-foreground: 240 4.8% 95.9%;
-    --sidebar-primary: 224.3 76.3% 48%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 3.7% 15.9%;
-    --sidebar-accent-foreground: 240 4.8% 95.9%;
-    --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
-  }
 }
 
 @layer base {
@@ -184,5 +150,46 @@ body {
   }
   body {
     @apply bg-background text-foreground;
+  }
+}
+
+@media print {
+  @page {
+    margin: 12mm;
+  }
+
+  body {
+    background: white !important;
+    color: black !important;
+    font-size: 10pt;
+  }
+
+  .print-hidden,
+  button,
+  [role='button'],
+  [data-radix-popper-content-wrapper] {
+    display: none !important;
+  }
+
+  .fixed,
+  .sticky {
+    position: static !important;
+  }
+
+  main,
+  .container {
+    max-width: none !important;
+    padding: 0 !important;
+  }
+
+  table {
+    width: 100% !important;
+    border-collapse: collapse;
+  }
+
+  tr,
+  img,
+  .card {
+    break-inside: avoid;
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,6 @@
 import type { Config } from 'tailwindcss'
 
 const config: Config = {
-  darkMode: ['class'],
   content: [
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',


### PR DESCRIPTION
## Summary
- make storefront and admin navigation responsive with 44px touch targets and mobile primary actions
- unify loading, print, confirmation, schedule validation, and unsaved-form behavior
- remove duplicate admin headers and unused dark-mode machinery
- normalize storefront titles, age-decline behavior, login UX, and fallback demo data

## Validation
- ./scripts/ci.sh
- 257 test files / 2101 tests
- coverage 58.61%
- production build passes

## Audit scope
C-1 through C-9, C-13, C-14; J-5 through J-7 and J-10 through J-13; K-4 and K-5 foundations.